### PR TITLE
fix: Add NVM path discovery for Claude CLI detection

### DIFF
--- a/CCSwitcher/Services/ClaudeService.swift
+++ b/CCSwitcher/Services/ClaudeService.swift
@@ -25,11 +25,14 @@ final class ClaudeService: Sendable {
     /// NVM stores node versions at ~/.nvm/versions/node/<version>/bin/.
     private static func nvmPaths() -> [String] {
         let nvmDir = "\(NSHomeDirectory())/.nvm/versions/node"
+        guard FileManager.default.fileExists(atPath: nvmDir) else { return [] }
         guard let versions = try? FileManager.default.contentsOfDirectory(atPath: nvmDir) else {
+            log.warning("[nvmPaths] NVM directory exists but could not be read: \(nvmDir)")
             return []
         }
-        // Sort descending so newer node versions are checked first
-        return versions.sorted().reversed().map { "\(nvmDir)/\($0)/bin/claude" }
+        return versions
+            .filter { !$0.hasPrefix(".") }
+            .map { "\(nvmDir)/\($0)/bin/claude" }
     }
 
     // MARK: - Auth Status
@@ -219,15 +222,18 @@ final class ClaudeService: Sendable {
                 var env = ProcessInfo.processInfo.environment
                 let homeDir = NSHomeDirectory()
                 // Include the parent directory of the discovered claude binary
-                // so that `node` is on PATH for NVM-installed scripts
-                let claudeBinDir = URL(fileURLWithPath: claudePath).deletingLastPathComponent().path
-                let extraPaths = [
-                    claudeBinDir,
+                // so that `node` is on PATH for NVM-installed scripts.
+                // Only add it when claudePath is absolute (skip the bare "claude" fallback).
+                var extraPaths = [
                     "/opt/homebrew/bin",
                     "/usr/local/bin",
                     "\(homeDir)/.local/bin",
                     "\(homeDir)/.npm-global/bin"
                 ]
+                if claudePath.contains("/") {
+                    let claudeBinDir = URL(fileURLWithPath: claudePath).deletingLastPathComponent().path
+                    extraPaths.insert(claudeBinDir, at: 0)
+                }
                 let existingPath = env["PATH"] ?? "/usr/bin:/bin"
                 env["PATH"] = (extraPaths + [existingPath]).joined(separator: ":")
                 env["HOME"] = homeDir

--- a/CCSwitcher/Services/ClaudeService.swift
+++ b/CCSwitcher/Services/ClaudeService.swift
@@ -15,10 +15,21 @@ final class ClaudeService: Sendable {
             "\(NSHomeDirectory())/.npm-global/bin/claude",
             "\(NSHomeDirectory())/.local/bin/claude",
             "\(NSHomeDirectory())/.claude/local/claude"
-        ]
+        ] + Self.nvmPaths()
         self.claudePath = possiblePaths.first { FileManager.default.fileExists(atPath: $0) }
             ?? "claude"
         log.info("Claude binary path: \(self.claudePath)")
+    }
+
+    /// Discover Claude binaries installed via NVM (Node Version Manager).
+    /// NVM stores node versions at ~/.nvm/versions/node/<version>/bin/.
+    private static func nvmPaths() -> [String] {
+        let nvmDir = "\(NSHomeDirectory())/.nvm/versions/node"
+        guard let versions = try? FileManager.default.contentsOfDirectory(atPath: nvmDir) else {
+            return []
+        }
+        // Sort descending so newer node versions are checked first
+        return versions.sorted().reversed().map { "\(nvmDir)/\($0)/bin/claude" }
     }
 
     // MARK: - Auth Status
@@ -207,7 +218,11 @@ final class ClaudeService: Sendable {
 
                 var env = ProcessInfo.processInfo.environment
                 let homeDir = NSHomeDirectory()
+                // Include the parent directory of the discovered claude binary
+                // so that `node` is on PATH for NVM-installed scripts
+                let claudeBinDir = URL(fileURLWithPath: claudePath).deletingLastPathComponent().path
                 let extraPaths = [
+                    claudeBinDir,
                     "/opt/homebrew/bin",
                     "/usr/local/bin",
                     "\(homeDir)/.local/bin",

--- a/CCSwitcher/Services/ClaudeService.swift
+++ b/CCSwitcher/Services/ClaudeService.swift
@@ -231,8 +231,11 @@ final class ClaudeService: Sendable {
                     "\(homeDir)/.npm-global/bin"
                 ]
                 if claudePath.contains("/") {
-                    let claudeBinDir = URL(fileURLWithPath: claudePath).deletingLastPathComponent().path
-                    extraPaths.insert(claudeBinDir, at: 0)
+                    // Resolve symlinks so that e.g. /usr/local/bin/claude -> ~/.nvm/.../bin/claude
+                    // yields the NVM bin dir where `node` actually lives
+                    let resolved = URL(fileURLWithPath: claudePath).resolvingSymlinksInPath().path
+                    let resolvedBinDir = URL(fileURLWithPath: resolved).deletingLastPathComponent().path
+                    extraPaths.insert(resolvedBinDir, at: 0)
                 }
                 let existingPath = env["PATH"] ?? "/usr/bin:/bin"
                 env["PATH"] = (extraPaths + [existingPath]).joined(separator: ":")


### PR DESCRIPTION
## Problem

Users who install Claude Code via `npm install -g @anthropic-ai/claude-code` under [NVM](https://github.com/nvm-sh/nvm) see **"Claude CLI not found"** in CCSwitcher, even though the CLI is installed and working in their terminal.

<img width="358" height="545" alt="Screenshot 2026-04-17 at 11 56 50 AM" src="https://github.com/user-attachments/assets/4c8ede74-e018-41c6-8234-3634a868a3a7" />


This happens because:
1. NVM installs binaries at `~/.nvm/versions/node/<version>/bin/`, which is not in the hardcoded `possiblePaths` list
2. macOS menu bar apps don't inherit the user's shell PATH (no `.zshrc` sourcing), so the bare `claude` fallback also fails

While the npm install method is no longer the officially recommended approach (the native binary installer is preferred), it still sees significant usage — [@anthropic-ai/claude-code has ~800k weekly downloads on npm](https://www.npmjs.com/package/@anthropic-ai/claude-code).

## Fix

**`ClaudeService.swift`** — two changes:

1. **`nvmPaths()`** — new helper that discovers Claude in `~/.nvm/versions/node/*/bin/`, with guards for missing directories, hidden entries, and a warning log when the NVM directory exists but is unreadable
2. **`runClaude()` PATH** — adds the parent directory of the discovered `claudePath` to the process environment PATH so `node` is available when running NVM-installed scripts. Guarded against the bare `"claude"` fallback to avoid `URL(fileURLWithPath:)` resolving against the process CWD

The NVM paths are checked *after* the existing hardcoded paths, so this is purely additive — users with standard installs see no behavior change.

## Test plan

- [ ] Verify on a machine with NVM-installed Claude that CCSwitcher detects the CLI
- [ ] Verify on a machine with native binary installer that behavior is unchanged
- [ ] Verify on a machine without NVM that `nvmPaths()` returns an empty array (no errors)