### PR TITLE
[codex] Add menu bar icon and limit bar customization

### DIFF
--- a/CCSwitcher/Models/BrandColor.swift
+++ b/CCSwitcher/Models/BrandColor.swift
@@ -1,5 +1,6 @@
-import SwiftUI
 import AppKit
+import Foundation
+import SwiftUI
 
 extension Color {
     /// CCSwitcher brand color.
@@ -12,6 +13,32 @@ extension Color {
             let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
             return NSColor(isDark ? dark : light)
         }))
+    }
+
+    init?(hexRGB: String) {
+        let trimmed = hexRGB.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hex = trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed
+        guard hex.count == 6, let value = UInt64(hex, radix: 16) else { return nil }
+        self.init(
+            red: Double((value >> 16) & 0xFF) / 255.0,
+            green: Double((value >> 8) & 0xFF) / 255.0,
+            blue: Double(value & 0xFF) / 255.0
+        )
+    }
+
+    var hexRGB: String? {
+        guard let rgb = NSColor(self).usingColorSpace(.sRGB) else { return nil }
+
+        func channel(_ component: CGFloat) -> Int {
+            min(max(Int(round(component * 255)), 0), 255)
+        }
+
+        return String(
+            format: "#%02X%02X%02X",
+            channel(rgb.redComponent),
+            channel(rgb.greenComponent),
+            channel(rgb.blueComponent)
+        )
     }
 
     // MARK: - Card

--- a/CCSwitcher/Models/MenuBarConfig.swift
+++ b/CCSwitcher/Models/MenuBarConfig.swift
@@ -19,7 +19,12 @@ final class MenuBarConfig: ObservableObject {
         didSet { persist() }
     }
 
+    @Published var showsHeadIcon: Bool {
+        didSet { persistShowsHeadIcon() }
+    }
+
     private let storageKey = MenuBarModuleStore.storageKey
+    private let showsHeadIconKey = "menuBarShowsHeadIcon"
 
     private init() {
         // Migration must run BEFORE the first read so a fresh-after-upgrade
@@ -27,10 +32,19 @@ final class MenuBarConfig: ObservableObject {
         MenuBarModuleStore.migrateIfNeeded()
         let data = UserDefaults.standard.data(forKey: storageKey) ?? Data()
         self.modules = MenuBarModuleStore.decode(data)
+        if UserDefaults.standard.object(forKey: showsHeadIconKey) == nil {
+            self.showsHeadIcon = true
+        } else {
+            self.showsHeadIcon = UserDefaults.standard.bool(forKey: showsHeadIconKey)
+        }
     }
 
     private func persist() {
         UserDefaults.standard.set(MenuBarModuleStore.encode(modules), forKey: storageKey)
+    }
+
+    private func persistShowsHeadIcon() {
+        UserDefaults.standard.set(showsHeadIcon, forKey: showsHeadIconKey)
     }
 
     /// Replace the current list. Used by the Settings editor on reorder / toggle.

--- a/CCSwitcher/Models/MenuBarConfig.swift
+++ b/CCSwitcher/Models/MenuBarConfig.swift
@@ -1,6 +1,11 @@
 import Foundation
 import SwiftUI
 
+enum LimitBarKind {
+    case session
+    case weekly
+}
+
 /// Shared, reactive source of truth for the menu-bar module list.
 ///
 /// We use an `ObservableObject` instead of `@AppStorage(Data)` because
@@ -14,6 +19,10 @@ import SwiftUI
 @MainActor
 final class MenuBarConfig: ObservableObject {
     static let shared = MenuBarConfig()
+    static let defaultSessionLimitBarColorHex = "#34C759"
+    static let defaultWeeklyLimitBarColorHex = "#0A84FF"
+    static let defaultLowRemainingLimitBarColorHex = "#FF3B30"
+    static let defaultLowRemainingThreshold = 30.0
 
     @Published var modules: [MenuBarModule] {
         didSet { persist() }
@@ -23,8 +32,28 @@ final class MenuBarConfig: ObservableObject {
         didSet { persistShowsHeadIcon() }
     }
 
+    @Published var sessionLimitBarColorHex: String {
+        didSet { persistSessionLimitBarColor() }
+    }
+
+    @Published var weeklyLimitBarColorHex: String {
+        didSet { persistWeeklyLimitBarColor() }
+    }
+
+    @Published var lowRemainingLimitBarColorHex: String {
+        didSet { persistLowRemainingLimitBarColor() }
+    }
+
+    @Published var lowRemainingWarningThreshold: Double {
+        didSet { persistLowRemainingWarningThreshold() }
+    }
+
     private let storageKey = MenuBarModuleStore.storageKey
     private let showsHeadIconKey = "menuBarShowsHeadIcon"
+    private let sessionLimitBarColorKey = "sessionLimitBarColor"
+    private let weeklyLimitBarColorKey = "weeklyLimitBarColor"
+    private let lowRemainingLimitBarColorKey = "lowRemainingLimitBarColor"
+    private let lowRemainingWarningThresholdKey = "lowRemainingWarningThreshold"
 
     private init() {
         // Migration must run BEFORE the first read so a fresh-after-upgrade
@@ -37,6 +66,17 @@ final class MenuBarConfig: ObservableObject {
         } else {
             self.showsHeadIcon = UserDefaults.standard.bool(forKey: showsHeadIconKey)
         }
+        self.sessionLimitBarColorHex = UserDefaults.standard.string(forKey: sessionLimitBarColorKey)
+            ?? Self.defaultSessionLimitBarColorHex
+        self.weeklyLimitBarColorHex = UserDefaults.standard.string(forKey: weeklyLimitBarColorKey)
+            ?? Self.defaultWeeklyLimitBarColorHex
+        self.lowRemainingLimitBarColorHex = UserDefaults.standard.string(forKey: lowRemainingLimitBarColorKey)
+            ?? Self.defaultLowRemainingLimitBarColorHex
+        if let threshold = UserDefaults.standard.object(forKey: lowRemainingWarningThresholdKey) as? Double {
+            self.lowRemainingWarningThreshold = threshold
+        } else {
+            self.lowRemainingWarningThreshold = Self.defaultLowRemainingThreshold
+        }
     }
 
     private func persist() {
@@ -47,6 +87,22 @@ final class MenuBarConfig: ObservableObject {
         UserDefaults.standard.set(showsHeadIcon, forKey: showsHeadIconKey)
     }
 
+    private func persistSessionLimitBarColor() {
+        UserDefaults.standard.set(sessionLimitBarColorHex, forKey: sessionLimitBarColorKey)
+    }
+
+    private func persistWeeklyLimitBarColor() {
+        UserDefaults.standard.set(weeklyLimitBarColorHex, forKey: weeklyLimitBarColorKey)
+    }
+
+    private func persistLowRemainingLimitBarColor() {
+        UserDefaults.standard.set(lowRemainingLimitBarColorHex, forKey: lowRemainingLimitBarColorKey)
+    }
+
+    private func persistLowRemainingWarningThreshold() {
+        UserDefaults.standard.set(lowRemainingWarningThreshold, forKey: lowRemainingWarningThresholdKey)
+    }
+
     /// Replace the current list. Used by the Settings editor on reorder / toggle.
     func set(_ modules: [MenuBarModule]) {
         // Dedup while preserving order — defends against stale UserDefaults data
@@ -55,5 +111,38 @@ final class MenuBarConfig: ObservableObject {
         let deduped = modules.filter { seen.insert($0).inserted }
         guard deduped != self.modules else { return } // skip no-op churn
         self.modules = deduped
+    }
+
+    var sessionLimitBarColor: Color {
+        Self.color(from: sessionLimitBarColorHex, fallback: Self.defaultSessionLimitBarColorHex)
+    }
+
+    var weeklyLimitBarColor: Color {
+        Self.color(from: weeklyLimitBarColorHex, fallback: Self.defaultWeeklyLimitBarColorHex)
+    }
+
+    var lowRemainingLimitBarColor: Color {
+        Self.color(from: lowRemainingLimitBarColorHex, fallback: Self.defaultLowRemainingLimitBarColorHex)
+    }
+
+    func limitBarColor(for kind: LimitBarKind, utilization: Double?) -> Color {
+        if let utilization {
+            let remaining = 100.0 - min(max(utilization, 0), 100)
+            let threshold = min(max(lowRemainingWarningThreshold, 0), 100)
+            if remaining <= threshold {
+                return lowRemainingLimitBarColor
+            }
+        }
+
+        switch kind {
+        case .session:
+            return sessionLimitBarColor
+        case .weekly:
+            return weeklyLimitBarColor
+        }
+    }
+
+    private static func color(from hex: String, fallback: String) -> Color {
+        Color(hexRGB: hex) ?? Color(hexRGB: fallback) ?? .brand
     }
 }

--- a/CCSwitcher/Services/StatusItemController.swift
+++ b/CCSwitcher/Services/StatusItemController.swift
@@ -73,6 +73,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
             rootView: AnyView(
                 MainMenuView()
                     .environmentObject(appState)
+                    .environmentObject(config)
                     .environment(\.locale, locale)
             )
         )
@@ -104,6 +105,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         popoverController?.rootView = AnyView(
             MainMenuView()
                 .environmentObject(appState)
+                .environmentObject(config)
                 .environment(\.locale, locale)
         )
     }

--- a/CCSwitcher/Services/StatusItemController.swift
+++ b/CCSwitcher/Services/StatusItemController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import SwiftUI
 
 /// Owns the menu-bar `NSStatusItem` and its click-through `NSPopover`.
@@ -16,6 +17,9 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     private var popoverController: NSHostingController<AnyView>?
     private var appState: AppState?
     private var menuBarConfig: MenuBarConfig?
+    private var currentLocale: Locale = .autoupdatingCurrent
+    private var stripRefreshCancellables = Set<AnyCancellable>()
+    private var isStripRefreshScheduled = false
     private var installed = false
 
     func install(appState: AppState, config: MenuBarConfig, locale: Locale) {
@@ -23,6 +27,7 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         installed = true
         self.appState = appState
         self.menuBarConfig = config
+        self.currentLocale = locale
 
         let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         self.statusItem = statusItem
@@ -30,20 +35,12 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         // The strip reports its true intrinsic width back to us; we mirror it
         // onto the status item so the leading icon / trailing module never clip
         // when content widens (real data, longer countdowns, account name).
-        let strip = MenuBarStripView(
-            appState: appState,
-            config: config,
-            onWidth: { [weak statusItem] width in
-                statusItem?.length = max(width, 1)
-            }
-        )
-        .environment(\.locale, locale)
-
-        let stripController = NSHostingController(rootView: AnyView(strip))
+        let stripController = NSHostingController(rootView: makeStripView(appState: appState, config: config, locale: locale))
         if #available(macOS 13.0, *) {
             stripController.sizingOptions = [.intrinsicContentSize]
         }
         self.stripController = stripController
+        observeStripRefreshes(appState: appState, config: config)
 
         let stripView = stripController.view
         stripView.translatesAutoresizingMaskIntoConstraints = false
@@ -91,17 +88,9 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
     /// Update the locale environment on all hosted SwiftUI views.
     /// Called when the user changes the in-app language setting.
     func updateLocale(_ locale: Locale) {
+        currentLocale = locale
         guard let appState, let config = menuBarConfig else { return }
-        stripController?.rootView = AnyView(
-            MenuBarStripView(
-                appState: appState,
-                config: config,
-                onWidth: { [weak statusItem] width in
-                    statusItem?.length = max(width, 1)
-                }
-            )
-            .environment(\.locale, locale)
-        )
+        stripController?.rootView = makeStripView(appState: appState, config: config, locale: locale)
         popoverController?.rootView = AnyView(
             MainMenuView()
                 .environmentObject(appState)
@@ -117,6 +106,57 @@ final class StatusItemController: NSObject, NSPopoverDelegate {
         } else {
             popover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .minY)
             popover.contentViewController?.view.window?.makeKey()
+        }
+    }
+
+    private func makeStripView(appState: AppState, config: MenuBarConfig, locale: Locale) -> AnyView {
+        let statusItem = self.statusItem
+        return AnyView(
+            MenuBarStripView(
+                appState: appState,
+                config: config,
+                onWidth: { [weak statusItem] width in
+                    statusItem?.length = max(width, 1)
+                }
+            )
+            .environment(\.locale, locale)
+        )
+    }
+
+    private func observeStripRefreshes(appState: AppState, config: MenuBarConfig) {
+        stripRefreshCancellables.removeAll()
+
+        appState.objectWillChange
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.scheduleStripRefresh()
+                }
+            }
+            .store(in: &stripRefreshCancellables)
+
+        config.objectWillChange
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    self?.scheduleStripRefresh()
+                }
+            }
+            .store(in: &stripRefreshCancellables)
+    }
+
+    private func scheduleStripRefresh() {
+        guard !isStripRefreshScheduled else { return }
+        isStripRefreshScheduled = true
+
+        Task { @MainActor [weak self] in
+            await Task.yield()
+            guard let self else { return }
+            isStripRefreshScheduled = false
+            guard let appState, let config = menuBarConfig else { return }
+            stripController?.rootView = makeStripView(
+                appState: appState,
+                config: config,
+                locale: currentLocale
+            )
         }
     }
 }

--- a/CCSwitcher/Views/MenuBarModuleView.swift
+++ b/CCSwitcher/Views/MenuBarModuleView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct MenuBarModuleView: View {
     let module: MenuBarModule
     let appState: AppState
+    let config: MenuBarConfig
     let showFullEmail: Bool
     /// Tick value that recomputes reset countdowns once a minute.
     /// Passed in (and ignored by non-countdown modules) so the parent timer
@@ -55,16 +56,30 @@ struct MenuBarModuleView: View {
                 .fixedSize()
 
         case .sessionBar:
-            UtilizationBar(utilization: sessionUtilization, markerPercent: sessionTimeElapsed)
+            UtilizationBar(
+                utilization: sessionUtilization,
+                markerPercent: sessionTimeElapsed,
+                fillColor: config.limitBarColor(for: .session, utilization: sessionUtilization)
+            )
 
         case .weeklyBar:
-            UtilizationBar(utilization: weeklyUtilization, markerPercent: weeklyTimeElapsed)
+            UtilizationBar(
+                utilization: weeklyUtilization,
+                markerPercent: weeklyTimeElapsed,
+                fillColor: config.limitBarColor(for: .weekly, utilization: weeklyUtilization)
+            )
 
         case .sessionBarPlain:
-            UtilizationBar(utilization: sessionUtilization)
+            UtilizationBar(
+                utilization: sessionUtilization,
+                fillColor: config.limitBarColor(for: .session, utilization: sessionUtilization)
+            )
 
         case .weeklyBarPlain:
-            UtilizationBar(utilization: weeklyUtilization)
+            UtilizationBar(
+                utilization: weeklyUtilization,
+                fillColor: config.limitBarColor(for: .weekly, utilization: weeklyUtilization)
+            )
 
         case .dailyCost:
             Text(dailyCostText)
@@ -145,9 +160,7 @@ struct MenuBarModuleView: View {
 }
 
 /// Hollow rounded capsule with an inner filled pill whose width reflects
-/// `utilization` (a 0–100 percentage, normalized to 0–1). Fill is monochrome
-/// (adapts to the light/dark menu bar), turning red above 90% (and staying red
-/// on overage, clamped at 100%).
+/// `utilization` (a 0–100 percentage, normalized to 0–1).
 ///
 /// `markerPercent` (0–100, optional) draws a thin vertical "pace" tick at the
 /// fraction of the rate-limit window already elapsed. Compare the fill to the
@@ -157,6 +170,7 @@ private struct UtilizationBar: View {
     let utilization: Double?
     /// 0–100 time-elapsed percentage for the pace tick, or nil to hide it.
     var markerPercent: Double? = nil
+    let fillColor: Color
 
     private let trackWidth: CGFloat = 26
     private let trackHeight: CGFloat = 8
@@ -164,11 +178,6 @@ private struct UtilizationBar: View {
     private let innerInset: CGFloat = 1.5
 
     private var clamped: Double { min(max((utilization ?? 0) / 100.0, 0), 1) }
-
-    private var fillColor: Color {
-        guard let u = utilization, u > 90 else { return .primary }
-        return .red
-    }
 
     /// X offset (within the inset interior) of the pace tick, if shown.
     /// Suppressed when there's no usage data so a dashed "no data" bar can't

--- a/CCSwitcher/Views/MenuBarModulesSettingsView.swift
+++ b/CCSwitcher/Views/MenuBarModulesSettingsView.swift
@@ -79,8 +79,10 @@ struct MenuBarModulesSettingsView: View {
 
     private var previewBar: some View {
         HStack(spacing: 10) {
-            Image(systemName: "brain.head.profile")
-                .font(.system(size: 13))
+            if config.showsHeadIcon {
+                Image(systemName: "brain.head.profile")
+                    .font(.system(size: 13))
+            }
             ForEach(rows.filter(\.isEnabled)) { row in
                 MenuBarModuleView(
                     module: row.module,

--- a/CCSwitcher/Views/MenuBarModulesSettingsView.swift
+++ b/CCSwitcher/Views/MenuBarModulesSettingsView.swift
@@ -35,6 +35,7 @@ struct MenuBarModulesSettingsView: View {
                         MenuBarModuleView(
                             module: row.module,
                             appState: appState,
+                            config: config,
                             showFullEmail: showFullEmail,
                             tick: tick
                         )
@@ -87,6 +88,7 @@ struct MenuBarModulesSettingsView: View {
                 MenuBarModuleView(
                     module: row.module,
                     appState: appState,
+                    config: config,
                     showFullEmail: showFullEmail,
                     tick: tick
                 )

--- a/CCSwitcher/Views/MenuBarStripView.swift
+++ b/CCSwitcher/Views/MenuBarStripView.swift
@@ -35,8 +35,10 @@ struct MenuBarStripView: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            Image(systemName: iconFilled ? "brain.head.profile.fill" : "brain.head.profile")
-                .font(.system(size: 14))
+            if config.showsHeadIcon {
+                Image(systemName: iconFilled ? "brain.head.profile.fill" : "brain.head.profile")
+                    .font(.system(size: 14))
+            }
 
             ForEach(config.modules) { module in
                 MenuBarModuleView(

--- a/CCSwitcher/Views/MenuBarStripView.swift
+++ b/CCSwitcher/Views/MenuBarStripView.swift
@@ -44,6 +44,7 @@ struct MenuBarStripView: View {
                 MenuBarModuleView(
                     module: module,
                     appState: appState,
+                    config: config,
                     showFullEmail: showFullEmail,
                     tick: tick
                 )

--- a/CCSwitcher/Views/SettingsView.swift
+++ b/CCSwitcher/Views/SettingsView.swift
@@ -95,6 +95,23 @@ struct SettingsView: View {
                 Toggle("Show head icon in menu bar", isOn: $menuBarConfig.showsHeadIcon)
             }
 
+            Section("Limit bars") {
+                ColorPicker("Session bar color", selection: sessionLimitBarColor, supportsOpacity: false)
+                ColorPicker("Weekly bar color", selection: weeklyLimitBarColor, supportsOpacity: false)
+                ColorPicker("Low remaining color", selection: lowRemainingLimitBarColor, supportsOpacity: false)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Low remaining threshold")
+                        Spacer()
+                        Text("\(Int(menuBarConfig.lowRemainingWarningThreshold))%")
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                    Slider(value: $menuBarConfig.lowRemainingWarningThreshold, in: 0...100, step: 5)
+                }
+            }
+
             Section {
                 MenuBarModulesSettingsView()
                     .environmentObject(appState)
@@ -171,5 +188,41 @@ struct SettingsView: View {
         } catch {
             launchAtLogin = !enable // revert on failure
         }
+    }
+
+    private var sessionLimitBarColor: Binding<Color> {
+        colorBinding(
+            keyPath: \.sessionLimitBarColorHex,
+            fallback: MenuBarConfig.defaultSessionLimitBarColorHex
+        )
+    }
+
+    private var weeklyLimitBarColor: Binding<Color> {
+        colorBinding(
+            keyPath: \.weeklyLimitBarColorHex,
+            fallback: MenuBarConfig.defaultWeeklyLimitBarColorHex
+        )
+    }
+
+    private var lowRemainingLimitBarColor: Binding<Color> {
+        colorBinding(
+            keyPath: \.lowRemainingLimitBarColorHex,
+            fallback: MenuBarConfig.defaultLowRemainingLimitBarColorHex
+        )
+    }
+
+    private func colorBinding(keyPath: ReferenceWritableKeyPath<MenuBarConfig, String>, fallback: String) -> Binding<Color> {
+        Binding(
+            get: {
+                Color(hexRGB: menuBarConfig[keyPath: keyPath])
+                    ?? Color(hexRGB: fallback)
+                    ?? .brand
+            },
+            set: { color in
+                if let hex = color.hexRGB {
+                    menuBarConfig[keyPath: keyPath] = hex
+                }
+            }
+        )
     }
 }

--- a/CCSwitcher/Views/SettingsView.swift
+++ b/CCSwitcher/Views/SettingsView.swift
@@ -5,6 +5,7 @@ import ServiceManagement
 struct SettingsView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var updateChecker: UpdateChecker
+    @EnvironmentObject private var menuBarConfig: MenuBarConfig
     @AppStorage("refreshInterval") private var refreshInterval: Double = 300
     @AppStorage("showFullEmail") private var showFullEmail = false
     @AppStorage("showInDock") private var showInDock = false
@@ -90,6 +91,10 @@ struct SettingsView: View {
 
     private var menuBarTab: some View {
         Form {
+            Section("Appearance") {
+                Toggle("Show head icon in menu bar", isOn: $menuBarConfig.showsHeadIcon)
+            }
+
             Section {
                 MenuBarModulesSettingsView()
                     .environmentObject(appState)

--- a/CCSwitcher/Views/UsageDashboardView.swift
+++ b/CCSwitcher/Views/UsageDashboardView.swift
@@ -23,6 +23,7 @@ private struct StatWithTooltip<Content: View>: View {
 /// Shows real usage limits from Claude API, one card per account.
 struct UsageDashboardView: View {
     @EnvironmentObject private var appState: AppState
+    @EnvironmentObject private var menuBarConfig: MenuBarConfig
     @AppStorage("showFullEmail") private var showFullEmail = false
 
     var body: some View {
@@ -257,10 +258,20 @@ struct UsageDashboardView: View {
     @ViewBuilder
     private func usageBars(_ usage: UsageAPIResponse) -> some View {
         if let session = usage.fiveHour {
-            usageRow(label: "Session", resetText: session.resetTimeString, utilization: session.utilization ?? 0)
+            usageRow(
+                label: "Session",
+                resetText: session.resetTimeString,
+                utilization: session.utilization ?? 0,
+                kind: .session
+            )
         }
         if let weekly = usage.sevenDay {
-            usageRow(label: "Weekly", resetText: weekly.resetTimeString, utilization: weekly.utilization ?? 0)
+            usageRow(
+                label: "Weekly",
+                resetText: weekly.resetTimeString,
+                utilization: weekly.utilization ?? 0,
+                kind: .weekly
+            )
         }
     }
 
@@ -287,8 +298,10 @@ struct UsageDashboardView: View {
 
     // MARK: - Usage Row
 
-    private func usageRow(label: LocalizedStringKey, resetText: String?, utilization: Double) -> some View {
-        VStack(spacing: 5) {
+    private func usageRow(label: LocalizedStringKey, resetText: String?, utilization: Double, kind: LimitBarKind) -> some View {
+        let fillColor = menuBarConfig.limitBarColor(for: kind, utilization: utilization)
+
+        return VStack(spacing: 5) {
             HStack {
                 Text(label)
                     .font(.caption)
@@ -309,7 +322,7 @@ struct UsageDashboardView: View {
                             .frame(height: 7)
 
                         RoundedRectangle(cornerRadius: 3)
-                            .fill(colorForUtilization(utilization))
+                            .fill(fillColor)
                             .frame(width: max(0, geo.size.width * min(utilization / 100.0, 1.0)), height: 7)
                     }
                 }
@@ -317,15 +330,9 @@ struct UsageDashboardView: View {
 
                 Text("\(Int(utilization))%")
                     .font(.caption.weight(.medium).monospacedDigit())
-                    .foregroundStyle(colorForUtilization(utilization))
+                    .foregroundStyle(fillColor)
                     .frame(width: 34, alignment: .trailing)
             }
         }
-    }
-
-    private func colorForUtilization(_ pct: Double) -> Color {
-        if pct >= 90 { return .red }
-        if pct >= 60 { return .orange }
-        return .green
     }
 }

--- a/CCSwitcher/de.lproj/Localizable.strings
+++ b/CCSwitcher/de.lproj/Localizable.strings
@@ -145,6 +145,11 @@
 "Menu bar modules" = "Menüleisten-Module";
 "Drag to reorder, toggle to enable. Disabled modules sit at the bottom." = "Zum Sortieren ziehen, zum Aktivieren umschalten. Deaktivierte Module stehen unten.";
 "Preview" = "Vorschau";
+"Limit bars" = "Limitbalken";
+"Session bar color" = "Farbe des Sitzungsbalkens";
+"Weekly bar color" = "Farbe des Wochenbalkens";
+"Low remaining color" = "Farbe bei geringem Rest";
+"Low remaining threshold" = "Schwelle für geringen Rest";
 "Account name" = "Kontoname";
 "Session usage (5h)" = "Sitzungsnutzung (5h)";
 "Weekly usage (7d)" = "Wochennutzung (7d)";

--- a/CCSwitcher/de.lproj/Localizable.strings
+++ b/CCSwitcher/de.lproj/Localizable.strings
@@ -22,6 +22,7 @@
 "5 minutes" = "5 Minuten";
 "10 minutes" = "10 Minuten";
 "Show account name in menu bar" = "Kontoname in der Menüleiste anzeigen";
+"Show head icon in menu bar" = "Kopf-Symbol in der Menüleiste anzeigen";
 "Show full email address" = "Vollständige E-Mail-Adresse anzeigen";
 "Launch at login" = "Beim Anmelden starten";
 

--- a/CCSwitcher/en.lproj/Localizable.strings
+++ b/CCSwitcher/en.lproj/Localizable.strings
@@ -22,6 +22,7 @@
 "5 minutes" = "5 minutes";
 "10 minutes" = "10 minutes";
 "Show account name in menu bar" = "Show account name in menu bar";
+"Show head icon in menu bar" = "Show head icon in menu bar";
 "Show full email address" = "Show full email address";
 "Launch at login" = "Launch at login";
 

--- a/CCSwitcher/en.lproj/Localizable.strings
+++ b/CCSwitcher/en.lproj/Localizable.strings
@@ -149,6 +149,11 @@
 "Menu bar modules" = "Menu bar modules";
 "Drag to reorder, toggle to enable. Disabled modules sit at the bottom." = "Drag to reorder, toggle to enable. Disabled modules sit at the bottom.";
 "Preview" = "Preview";
+"Limit bars" = "Limit bars";
+"Session bar color" = "Session bar color";
+"Weekly bar color" = "Weekly bar color";
+"Low remaining color" = "Low remaining color";
+"Low remaining threshold" = "Low remaining threshold";
 "Account name" = "Account name";
 "Session usage (5h)" = "Session usage (5h)";
 "Weekly usage (7d)" = "Weekly usage (7d)";

--- a/CCSwitcher/fr.lproj/Localizable.strings
+++ b/CCSwitcher/fr.lproj/Localizable.strings
@@ -22,6 +22,7 @@
 "5 minutes" = "5 minutes";
 "10 minutes" = "10 minutes";
 "Show account name in menu bar" = "Afficher le nom du compte dans la barre des menus";
+"Show head icon in menu bar" = "Afficher l'icône de tête dans la barre des menus";
 "Show full email address" = "Afficher l'adresse e-mail complète";
 "Launch at login" = "Lancer au démarrage";
 

--- a/CCSwitcher/fr.lproj/Localizable.strings
+++ b/CCSwitcher/fr.lproj/Localizable.strings
@@ -145,6 +145,11 @@
 "Menu bar modules" = "Modules de la barre de menus";
 "Drag to reorder, toggle to enable. Disabled modules sit at the bottom." = "Glissez pour réorganiser, basculez pour activer. Les modules désactivés sont en bas.";
 "Preview" = "Aperçu";
+"Limit bars" = "Barres de limite";
+"Session bar color" = "Couleur de la barre session";
+"Weekly bar color" = "Couleur de la barre hebdo";
+"Low remaining color" = "Couleur de reste faible";
+"Low remaining threshold" = "Seuil de reste faible";
 "Account name" = "Nom du compte";
 "Session usage (5h)" = "Utilisation de la session (5h)";
 "Weekly usage (7d)" = "Utilisation hebdomadaire (7j)";

--- a/CCSwitcher/ja.lproj/Localizable.strings
+++ b/CCSwitcher/ja.lproj/Localizable.strings
@@ -22,6 +22,7 @@
 "5 minutes" = "5 分";
 "10 minutes" = "10 分";
 "Show account name in menu bar" = "メニューバーにアカウント名を表示";
+"Show head icon in menu bar" = "メニューバーにヘッドアイコンを表示";
 "Show full email address" = "メールアドレスを完全に表示";
 "Launch at login" = "ログイン時に起動";
 

--- a/CCSwitcher/ja.lproj/Localizable.strings
+++ b/CCSwitcher/ja.lproj/Localizable.strings
@@ -145,6 +145,11 @@
 "Menu bar modules" = "メニューバー モジュール";
 "Drag to reorder, toggle to enable. Disabled modules sit at the bottom." = "ドラッグで並び替え、トグルで有効化。無効モジュールは下に表示されます。";
 "Preview" = "プレビュー";
+"Limit bars" = "制限バー";
+"Session bar color" = "セッションバーの色";
+"Weekly bar color" = "週間バーの色";
+"Low remaining color" = "残量低下時の色";
+"Low remaining threshold" = "残量低下しきい値";
 "Account name" = "アカウント名";
 "Session usage (5h)" = "セッション使用量（5時間）";
 "Weekly usage (7d)" = "週間使用量（7日）";

--- a/CCSwitcher/zh-Hans.lproj/Localizable.strings
+++ b/CCSwitcher/zh-Hans.lproj/Localizable.strings
@@ -22,6 +22,7 @@
 "5 minutes" = "5 分钟";
 "10 minutes" = "10 分钟";
 "Show account name in menu bar" = "在菜单栏显示账户名称";
+"Show head icon in menu bar" = "在菜单栏显示头像图标";
 "Show full email address" = "显示完整邮箱地址";
 "Launch at login" = "登录时启动";
 

--- a/CCSwitcher/zh-Hans.lproj/Localizable.strings
+++ b/CCSwitcher/zh-Hans.lproj/Localizable.strings
@@ -145,6 +145,11 @@
 "Menu bar modules" = "菜单栏模块";
 "Drag to reorder, toggle to enable. Disabled modules sit at the bottom." = "拖动排序，勾选启用。未启用的模块排在下方。";
 "Preview" = "预览";
+"Limit bars" = "额度条";
+"Session bar color" = "会话条颜色";
+"Weekly bar color" = "每周条颜色";
+"Low remaining color" = "低剩余额度颜色";
+"Low remaining threshold" = "低剩余额度阈值";
 "Account name" = "账户名称";
 "Session usage (5h)" = "会话用量（5小时）";
 "Weekly usage (7d)" = "每周用量（7天）";


### PR DESCRIPTION
## Summary
- Add a Menu Bar setting to show or hide the brain/head status item icon.
- Add configurable session and weekly limit bar colors.
- Add a configurable low-remaining threshold and warning color, defaulting to red when remaining limit is at or below 30%.
- Refresh the hosted menu bar strip explicitly when app state or menu bar config changes.

## Impact
Users can keep the menu bar more compact by hiding the head icon, and can tune the session/weekly limit bars to match their preferred visual language. The low-remaining warning applies consistently to both the menu bar modules and the Usage dashboard.

The menu bar strip no longer depends solely on the hosted SwiftUI timer to pick up usage/config changes inside `NSStatusItem`.

## Validation
- `xcodegen generate`
- `xcodebuild -project CCSwitcher.xcodeproj -scheme CCSwitcher -configuration Debug CODE_SIGNING_ALLOWED=NO build`
