### PR TITLE
feat: Proactive auto-switch before hitting rate limits (opt-in)

### DIFF
--- a/CCSwitcher/AppState.swift
+++ b/CCSwitcher/AppState.swift
@@ -43,6 +43,29 @@ final class AppState: ObservableObject {
     private let accountsKey = "com.ccswitcher.accounts"
     private var refreshTimer: Timer?
 
+    // MARK: - Auto-switch
+
+    /// Whether proactive auto-switch is on (written by SettingsView via @AppStorage).
+    private var autoSwitchEnabled: Bool {
+        UserDefaults.standard.bool(forKey: "autoSwitchEnabled")
+    }
+
+    /// Utilization percentage at which we switch. Defaults to 90 when unset.
+    private var autoSwitchThreshold: Double {
+        let stored = UserDefaults.standard.double(forKey: "autoSwitchThreshold")
+        return stored == 0 ? 90 : stored
+    }
+
+    /// A candidate must sit at least this far below the threshold to be eligible,
+    /// so two accounts hovering at the line never ping-pong.
+    private let autoSwitchHysteresis: Double = 10
+
+    /// Minimum gap between two automatic switches, to avoid rapid flip-flopping.
+    private let autoSwitchCooldown: TimeInterval = 300
+
+    private var lastAutoSwitchAt: Date?
+    private var isEvaluatingAutoSwitch = false
+
     // MARK: - Initialization
 
     init() {
@@ -98,6 +121,10 @@ final class AppState: ObservableObject {
 
         updateWidgetData()
         isLoading = false
+
+        // Proactive auto-switch: after usage is refreshed, switch off the active
+        // account if it has reached the threshold. Guarded by cooldown + re-entrancy.
+        await evaluateAutoSwitch()
     }
 
     func startAutoRefresh(interval: TimeInterval = 300) {
@@ -319,6 +346,54 @@ final class AppState: ObservableObject {
             isLoading = false
             log.error("[switchTo] Switch failed: \(error.localizedDescription)")
         }
+    }
+
+    // MARK: - Auto-switch
+
+    /// Whether an account can be switched to right now: it must have a stored
+    /// backup token and not be flagged expired (an expired backup would fail the
+    /// switch verification, or silently swap in a dead session).
+    private func isSwitchable(_ account: Account) -> Bool {
+        guard keychain.getAccountBackup(forAccountId: account.id.uuidString) != nil else { return false }
+        if let error = accountUsageErrors[account.id], error.isExpired { return false }
+        return true
+    }
+
+    /// Evaluate whether the active account has reached the threshold and, if so,
+    /// switch to the same-provider account with the most quota left.
+    /// Called at the end of every `refresh()`. Safe to call repeatedly.
+    private func evaluateAutoSwitch() async {
+        guard autoSwitchEnabled, !isEvaluatingAutoSwitch else { return }
+        guard let active = activeAccount else { return }
+
+        // Cooldown: never auto-switch more than once per window.
+        if let last = lastAutoSwitchAt, Date().timeIntervalSince(last) < autoSwitchCooldown {
+            return
+        }
+
+        // Only consider same-provider accounts (a Claude switch never touches Codex/Gemini).
+        let candidates = accounts.filter { $0.provider == active.provider && $0.id != active.id }
+        guard let target = AutoSwitchEngine.chooseTarget(
+            active: active,
+            candidates: candidates,
+            usageByAccount: accountUsage,
+            isSwitchable: { [unowned self] in self.isSwitchable($0) },
+            threshold: autoSwitchThreshold,
+            hysteresisPct: autoSwitchHysteresis
+        ) else {
+            return
+        }
+
+        let activeUtil = AutoSwitchEngine.bindingUtilization(accountUsage[active.id]) ?? -1
+        log.info("[autoSwitch] \(active.email) reached \(String(format: "%.0f", activeUtil))% (threshold \(String(format: "%.0f", self.autoSwitchThreshold))%) -> switching to \(target.email)")
+
+        isEvaluatingAutoSwitch = true
+        lastAutoSwitchAt = Date()
+        // switchTo() calls refresh() -> evaluateAutoSwitch() again, but the
+        // re-entrancy flag + the freshly-set cooldown make that a no-op.
+        // The active account visibly changes in the menu bar as feedback.
+        await switchTo(target)
+        isEvaluatingAutoSwitch = false
     }
 
     /// Re-authenticate an account by running `claude auth login` and capturing fresh credentials.

--- a/CCSwitcher/Services/AutoSwitchEngine.swift
+++ b/CCSwitcher/Services/AutoSwitchEngine.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Pure, UI-agnostic auto-switch decision logic.
+///
+/// Mirrors the proven design in `claude-swap` (threshold + hysteresis): when the
+/// active account's *binding window* (the higher of its 5h / weekly utilization)
+/// reaches the configured threshold, pick the same-provider account with the most
+/// quota left — but only one that sits at least `hysteresisPct` below the threshold,
+/// so two accounts hovering at the line never ping-pong. All guardrails that need
+/// state (cooldown, re-entrancy) live in `AppState`; this stays a pure function.
+enum AutoSwitchEngine {
+
+    /// The binding utilization for an account = max of the windows we watch.
+    /// We watch the 5-hour (session) and 7-day (weekly-all) windows — the two
+    /// that the `/api/oauth/usage` endpoint still populates as top-level fields.
+    /// Returns nil when we have no usage sample for the account.
+    static func bindingUtilization(_ usage: UsageAPIResponse?) -> Double? {
+        guard let usage else { return nil }
+        let windows = [usage.fiveHour?.utilization, usage.sevenDay?.utilization]
+        return windows.compactMap { $0 }.max()
+    }
+
+    /// Decide whether to switch, and to which account.
+    ///
+    /// - Parameters:
+    ///   - active: the currently active account.
+    ///   - candidates: every other account (already filtered to the same provider).
+    ///   - usageByAccount: latest usage sample per account id.
+    ///   - isSwitchable: whether an account can actually be switched to right now
+    ///     (has a stored backup token and isn't flagged expired).
+    ///   - threshold: switch when the active binding utilization is >= this (e.g. 90).
+    ///   - hysteresisPct: a candidate must sit at least this far below the threshold
+    ///     to be eligible (e.g. 10 -> candidate must be <= threshold - 10).
+    /// - Returns: the best account to switch to, or nil to stay put.
+    static func chooseTarget(
+        active: Account,
+        candidates: [Account],
+        usageByAccount: [UUID: UsageAPIResponse],
+        isSwitchable: (Account) -> Bool,
+        threshold: Double,
+        hysteresisPct: Double
+    ) -> Account? {
+        // 1) Only act once the active account has reached the threshold on a
+        //    window we watch. Unknown active usage -> do nothing (can't decide).
+        guard let activeUtil = bindingUtilization(usageByAccount[active.id]),
+              activeUtil >= threshold else {
+            return nil
+        }
+
+        // 2) Keep only switchable candidates that sit safely below the threshold.
+        //    Unknown-usage candidates are allowed as a failover fallback (they may
+        //    simply not have been sampled yet), but they sort last (see step 3).
+        let ceiling = threshold - hysteresisPct
+        let viable = candidates.filter { candidate in
+            guard candidate.id != active.id, isSwitchable(candidate) else { return false }
+            guard let util = bindingUtilization(usageByAccount[candidate.id]) else { return true }
+            return util <= ceiling
+        }
+
+        // 3) Prefer the account with the most headroom (lowest known utilization);
+        //    accounts with no usage sample sort last as a fallback.
+        return viable.min { lhs, rhs in
+            let lhsUtil = bindingUtilization(usageByAccount[lhs.id]) ?? .greatestFiniteMagnitude
+            let rhsUtil = bindingUtilization(usageByAccount[rhs.id]) ?? .greatestFiniteMagnitude
+            return lhsUtil < rhsUtil
+        }
+    }
+}

--- a/CCSwitcher/Views/SettingsView.swift
+++ b/CCSwitcher/Views/SettingsView.swift
@@ -9,6 +9,8 @@ struct SettingsView: View {
     @AppStorage("showFullEmail") private var showFullEmail = false
     @AppStorage("showInDock") private var showInDock = false
     @AppStorage("appLanguage") private var appLanguage = "auto"
+    @AppStorage("autoSwitchEnabled") private var autoSwitchEnabled = false
+    @AppStorage("autoSwitchThreshold") private var autoSwitchThreshold = 90.0
     @State private var launchAtLogin = false
 
     var body: some View {
@@ -53,6 +55,25 @@ struct SettingsView: View {
                 }
                 .onChange(of: refreshInterval) { _, newValue in
                     appState.startAutoRefresh(interval: newValue)
+                }
+            }
+
+            Section("Auto-switch") {
+                Toggle("Switch account before hitting the limit", isOn: $autoSwitchEnabled)
+                if autoSwitchEnabled {
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Text("Switch at")
+                            Spacer()
+                            Text("\(Int(autoSwitchThreshold))%")
+                                .monospacedDigit()
+                                .foregroundStyle(.secondary)
+                        }
+                        Slider(value: $autoSwitchThreshold, in: 50...99, step: 1)
+                    }
+                    Text("When the active account's 5-hour or weekly usage reaches this level, CCSwitcher switches to the account with the most quota left. Checked on every refresh; a 5-minute cooldown prevents rapid flip-flopping.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             }
 


### PR DESCRIPTION
## What

Opt-in **auto-switch**: when the active account's 5-hour or weekly utilization reaches a configurable threshold (default **90%**), CCSwitcher automatically switches to the saved account with the most quota left - so a running Claude Code session simply continues on the next request with a fresh account instead of stopping at the limit.

Everything needed already existed in the app (per-account usage via `/api/oauth/usage`, the verified `switchTo` flow, the periodic refresh timer) - this PR only adds the decision layer and a settings UI on top.

## How

- **New `Services/AutoSwitchEngine.swift`** - pure, UI-independent decision logic:
  - binding utilization = `max(five_hour, seven_day)` for an account
  - a candidate must have a stored backup token, not be flagged expired, and sit at least **10% below the threshold** (hysteresis - two accounts hovering at the line never ping-pong); best candidate = most headroom
- **`AppState`** - `evaluateAutoSwitch()` runs at the end of every `refresh()`, guarded by:
  - 5-minute cooldown between automatic switches
  - re-entrancy flag (the `switchTo -> refresh` recursion is a no-op)
  - same-provider candidates only (a Claude switch never touches Codex/Gemini accounts)
  - unknown active usage -> do nothing
- **`SettingsView`** - new *Auto-switch* section on the General tab: enable toggle + threshold slider (50-99%), persisted via `@AppStorage` like the existing settings.

## Defaults / safety

- **Default OFF** - zero behavior change unless the user enables it.
- No new dependencies, no new permissions, no notifications (the menu bar visibly reflects the switch; details go to the existing FileLog).
- The threshold + hysteresis + cooldown design follows the proven approach of existing auto-switchers (e.g. claude-swap).

## Testing

- Built with XcodeGen + Xcode 26.4 (Debug and Release), running locally on macOS 26.
- `AutoSwitchEngine` is a pure function and easy to unit-test; happy to add tests if you'd like them in a specific place.

## Possible follow-up (not in this PR)

The usage endpoint now reports per-model weekly limits (e.g. Fable) in the new `limits` array (`weekly_scoped`) instead of the old `seven_day_opus`/`seven_day_sonnet` top-level keys (both are `null` now). Parsing that array would let the auto-switch also react to per-model quotas - happy to do that as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)