### PR TITLE
fix: don't fail a switch when `claude auth status` omits the account (#18)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -207,7 +207,7 @@ Step 3: OVERWRITE the LIVE slot with target token
 
 Step 4: VERIFY the switch worked
 
-    Run `claude auth status` → returns { email: "?", loggedIn: ? }
+    Run `claude auth status` → returns { authMethod, email?, loggedIn }
 
     ┌─────────────────────────────────────────────────────────────────────────┐
     │ if !loggedIn:                                                           │
@@ -216,12 +216,31 @@ Step 4: VERIFY the switch worked
     │ if email == B.email:                                                    │
     │   → SUCCESS. Claude CLI now operates as Account B.                     │
     │                                                                         │
-    │ if email != B.email (e.g. still A, or unknown):                        │
+    │ if email is present but != B.email:                                    │
     │   → Backup T-B was CORRUPTED (contained wrong account's token).        │
     │   → throw switchWrongAccount(expected: B, actual: email)               │
     │   → User sees: "Switch failed: expected B@... but got A@...            │
     │     Try removing and re-adding the account."                           │
+    │                                                                         │
+    │ if email is ABSENT (authMethod != "claude.ai"):                        │
+    │   → Says NOTHING about our swap — see the note below.                  │
+    │   → Fall back to a local check: LIVE keychain accessToken == T-B's,    │
+    │     and ~/.claude.json identity == B.email.                            │
+    │   → match    → SUCCESS, plus a warning naming the shadowing source.    │
+    │   → mismatch → throw switchVerificationFailed                          │
     └─────────────────────────────────────────────────────────────────────────┘
+
+    ⚠️  `claude auth status` only emits `email` / `orgId` / `orgName` /
+        `subscriptionType` when `authMethod == "claude.ai"`, i.e. when the
+        stored claude.ai login is the credential source the CLI actually
+        resolves to. Any higher-precedence source shadows it and the whole
+        identity block is omitted while `loggedIn` stays `true`:
+        `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, an `apiKeyHelper`,
+        an OAuth token file, an Anthropic profile in `~/.config/anthropic`,
+        or a third-party provider (Bedrock/Vertex/…). Treating that absence
+        as "wrong account" produced the bogus
+        "Switch failed: expected <email> but got unknown" of issue #18, even
+        though both halves of the swap had been written correctly.
 
 Step 5: POST-SWITCH diagnostics
 

--- a/CCSwitcher/AppState.swift
+++ b/CCSwitcher/AppState.swift
@@ -127,9 +127,14 @@ final class AppState: ObservableObject {
 
         do {
             let status = try await claudeService.getAuthStatus()
-            guard status.loggedIn, let email = status.email else {
+            guard status.loggedIn else {
                 errorMessage = String(localized: "Not logged in to Claude. Run 'claude auth login' first.", bundle: L10n.bundle)
                 log.error("[addAccount] Aborted: not logged in")
+                return
+            }
+            guard let email = status.email else {
+                errorMessage = shadowedIdentityMessage(status)
+                log.error("[addAccount] Aborted: CLI reports authMethod=\(status.authMethod ?? "nil") without an account identity")
                 return
             }
             log.info("[addAccount] Current auth: logged in, sub=\(status.subscriptionType ?? "nil")")
@@ -203,9 +208,15 @@ final class AppState: ObservableObject {
             // 3. Read the new identity from ~/.claude.json
             log.info("[loginNewAccount] Step 3: Reading post-login state...")
             let status = try await claudeService.getAuthStatus()
-            guard status.loggedIn, let email = status.email else {
+            guard status.loggedIn else {
                 errorMessage = String(localized: "Login did not complete", bundle: L10n.bundle)
                 log.error("[loginNewAccount] Step 3: Not logged in after login!")
+                isLoggingIn = false
+                return
+            }
+            guard let email = status.email else {
+                errorMessage = shadowedIdentityMessage(status)
+                log.error("[loginNewAccount] Step 3: CLI reports authMethod=\(status.authMethod ?? "nil") without an account identity")
                 isLoggingIn = false
                 return
             }
@@ -301,7 +312,7 @@ final class AppState: ObservableObject {
 
         isLoading = true
         do {
-            try await claudeService.switchAccount(from: currentActive, to: account)
+            let outcome = try await claudeService.switchAccount(from: currentActive, to: account)
 
             for i in accounts.indices {
                 accounts[i].isActive = (accounts[i].id == account.id)
@@ -313,6 +324,10 @@ final class AppState: ObservableObject {
             saveAccounts()
 
             await refresh()
+            // `refresh()` clears errorMessage, so surface the warning afterwards.
+            if let shadowedBy = outcome.shadowedBy {
+                errorMessage = String(localized: "Switched to \(account.email), but the Claude CLI is authenticating via \(shadowedBy) instead of the stored login, so it will not use this account.", bundle: L10n.bundle)
+            }
             log.info("[switchTo] ===== Switch completed =====")
         } catch {
             errorMessage = error.localizedDescription
@@ -345,8 +360,14 @@ final class AppState: ObservableObject {
 
             // 3. Verify the login result matches the target account
             let status = try await claudeService.getAuthStatus()
-            guard status.loggedIn, let email = status.email else {
+            guard status.loggedIn else {
                 errorMessage = String(localized: "Login did not complete", bundle: L10n.bundle)
+                isLoggingIn = false
+                return
+            }
+            guard let email = status.email else {
+                errorMessage = shadowedIdentityMessage(status)
+                log.error("[reauth] CLI reports authMethod=\(status.authMethod ?? "nil") without an account identity")
                 isLoggingIn = false
                 return
             }
@@ -447,6 +468,15 @@ final class AppState: ObservableObject {
     }
 
     // MARK: - Diagnostics
+
+    /// Message for the case where the CLI *is* authenticated but reports no
+    /// account, because a credential source outranking the stored claude.ai login
+    /// is in play. Without this the user only saw "Not logged in" / "Login did not
+    /// complete" and re-authorized in a loop that could never help (issue #18).
+    private func shadowedIdentityMessage(_ status: AuthStatus) -> String {
+        let method = status.shadowingAuthMethod ?? "unknown"
+        return String(localized: "Claude CLI is authenticating via \(method) instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again.", bundle: L10n.bundle)
+    }
 
     /// Passive health check — verifies backup existence and identity consistency.
     private func diagnoseTokenHealth() {

--- a/CCSwitcher/Models/Account.swift
+++ b/CCSwitcher/Models/Account.swift
@@ -98,6 +98,17 @@ struct Account: Identifiable, Codable, Hashable {
 
 // MARK: - Auth Status (from `claude auth status`)
 
+/// Decoded `claude auth status` output.
+///
+/// The CLI only emits `email`, `orgId`, `orgName` and `subscriptionType` when
+/// `authMethod == "claude.ai"` — that is, when the stored claude.ai login is the
+/// credential source it actually resolves to. Any higher-precedence source
+/// shadows the stored login and the whole identity block is omitted while
+/// `loggedIn` stays `true`: an `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN`
+/// environment variable, an `apiKeyHelper`, an OAuth token file, an Anthropic
+/// profile in `~/.config/anthropic`, or a third-party provider (Bedrock, Vertex,
+/// …). Callers must therefore treat a missing `email` as "identity unavailable",
+/// never as "a different account is active".
 struct AuthStatus: Codable {
     let loggedIn: Bool
     let authMethod: String?
@@ -106,4 +117,16 @@ struct AuthStatus: Codable {
     let orgId: String?
     let orgName: String?
     let subscriptionType: String?
+
+    /// True when the CLI reports the identity of the stored claude.ai login,
+    /// i.e. when `email` is meaningful.
+    var reportsClaudeAiIdentity: Bool {
+        authMethod == "claude.ai"
+    }
+
+    /// The credential source shadowing the stored claude.ai login, or `nil` when
+    /// nothing shadows it. Only meaningful while `loggedIn` is `true`.
+    var shadowingAuthMethod: String? {
+        reportsClaudeAiIdentity ? nil : (authMethod ?? "unknown")
+    }
 }

--- a/CCSwitcher/Services/ClaudeService.swift
+++ b/CCSwitcher/Services/ClaudeService.swift
@@ -270,7 +270,15 @@ final class ClaudeService: @unchecked Sendable {
 
     // MARK: - Account Switching
 
-    func switchAccount(from currentAccount: Account, to targetAccount: Account) async throws {
+    /// Result of a completed switch.
+    struct SwitchOutcome {
+        /// Set when the swap succeeded but `claude auth status` could not confirm
+        /// it, because this credential source shadows the stored claude.ai login.
+        let shadowedBy: String?
+    }
+
+    @discardableResult
+    func switchAccount(from currentAccount: Account, to targetAccount: Account) async throws -> SwitchOutcome {
         let keychain = KeychainService.shared
 
         log.info("[switchAccount] Switching from \(currentAccount.id) to \(targetAccount.id)")
@@ -318,11 +326,52 @@ final class ClaudeService: @unchecked Sendable {
             log.error("[switchAccount] Step 4: Not logged in after switch!")
             throw ClaudeServiceError.switchVerificationFailed
         }
-        if status.email != targetAccount.email {
-            log.error("[switchAccount] Step 4: Logged in as \(status.email ?? "nil") instead of \(targetAccount.email)")
-            throw ClaudeServiceError.switchWrongAccount(expected: targetAccount.email, actual: status.email ?? "unknown")
+
+        if let email = status.email {
+            guard email == targetAccount.email else {
+                log.error("[switchAccount] Step 4: Logged in as \(email) instead of \(targetAccount.email)")
+                throw ClaudeServiceError.switchWrongAccount(expected: targetAccount.email, actual: email)
+            }
+            log.info("[switchAccount] Step 4: Switch verified — logged in as \(email)")
+            return SwitchOutcome(shadowedBy: nil)
         }
-        log.info("[switchAccount] Step 4: Switch verified — logged in as \(status.email ?? "")")
+
+        // No `email` in the status output. The CLI is logged in, but resolves to a
+        // credential source that outranks the stored claude.ai login (env token,
+        // apiKeyHelper, OAuth token file, Anthropic profile, third-party provider),
+        // so it omits the identity block entirely. That says nothing about whether
+        // our swap worked, so verify against the credentials we just wrote instead
+        // of reporting the target account as "wrong" (issue #18).
+        let shadowedBy = status.shadowingAuthMethod ?? "unknown"
+        log.warning("[switchAccount] Step 4: CLI reports authMethod=\(shadowedBy) and omits the account identity; verifying against the credential store instead")
+        guard credentialsOnDiskMatch(backup: targetBackup, email: targetAccount.email) else {
+            throw ClaudeServiceError.switchVerificationFailed
+        }
+        log.info("[switchAccount] Step 4: Switch verified against the credential store (CLI identity hidden by \(shadowedBy))")
+        return SwitchOutcome(shadowedBy: shadowedBy)
+    }
+
+    /// Ground-truth check that does not depend on `claude auth status`: both
+    /// halves of a switch — the keychain token and the `~/.claude.json` identity —
+    /// must hold the target account.
+    private func credentialsOnDiskMatch(backup: AccountBackup, email: String) -> Bool {
+        let keychain = KeychainService.shared
+
+        guard let liveToken = keychain.readClaudeToken(),
+              let liveAccessToken = Self.extractAccessToken(from: liveToken),
+              let expectedAccessToken = Self.extractAccessToken(from: backup.token),
+              liveAccessToken == expectedAccessToken else {
+            log.error("[switchAccount] Keychain token does not match the target account's backup")
+            return false
+        }
+
+        guard let liveOAuth = keychain.readOAuthAccount(),
+              (liveOAuth["emailAddress"]?.value as? String) == email else {
+            log.error("[switchAccount] ~/.claude.json identity does not match \(email)")
+            return false
+        }
+
+        return true
     }
 
     /// Capture the current Claude auth token + oauthAccount and associate with an account

--- a/CCSwitcher/de.lproj/Localizable.strings
+++ b/CCSwitcher/de.lproj/Localizable.strings
@@ -130,6 +130,8 @@
 "Could not capture credentials" = "Anmeldedaten konnten nicht erfasst werden";
 "No stored credentials for %@. Use re-authenticate to fix." = "Keine gespeicherten Anmeldedaten für %@. Verwenden Sie Erneut authentifizieren zur Behebung.";
 "Logged in as %@, but expected %@. Credentials not updated." = "Angemeldet als %1$@, aber %2$@ erwartet. Anmeldedaten nicht aktualisiert.";
+"Claude CLI is authenticating via %@ instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again." = "Die Claude CLI authentifiziert sich über %@ statt über eine gespeicherte claude.ai-Anmeldung und meldet daher kein Konto. Heben Sie ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE auf, entfernen Sie einen etwaigen apiKeyHelper und versuchen Sie es erneut.";
+"Switched to %@, but the Claude CLI is authenticating via %@ instead of the stored login, so it will not use this account." = "Zu %1$@ gewechselt, aber die Claude CLI authentifiziert sich über %2$@ statt über die gespeicherte Anmeldung und verwendet dieses Konto daher nicht.";
 "Token expired. Switch to refresh." = "Token abgelaufen. Wechseln zum Aktualisieren.";
 "Token expired. Switch to this account to refresh." = "Token abgelaufen. Zu diesem Konto wechseln zum Aktualisieren.";
 "API Rate Limited. Try again later." = "API-Anfragelimit erreicht. Bitte später erneut versuchen.";

--- a/CCSwitcher/en.lproj/Localizable.strings
+++ b/CCSwitcher/en.lproj/Localizable.strings
@@ -130,6 +130,8 @@
 "Could not capture credentials" = "Could not capture credentials";
 "No stored credentials for %@. Use re-authenticate to fix." = "No stored credentials for %@. Use re-authenticate to fix.";
 "Logged in as %@, but expected %@. Credentials not updated." = "Logged in as %1$@, but expected %2$@. Credentials not updated.";
+"Claude CLI is authenticating via %@ instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again." = "Claude CLI is authenticating via %@ instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again.";
+"Switched to %@, but the Claude CLI is authenticating via %@ instead of the stored login, so it will not use this account." = "Switched to %1$@, but the Claude CLI is authenticating via %2$@ instead of the stored login, so it will not use this account.";
 "Token expired. Switch to refresh." = "Token expired. Switch to refresh.";
 "Token expired. Switch to this account to refresh." = "Token expired. Switch to this account to refresh.";
 "API Rate Limited. Try again later." = "API Rate Limited. Try again later.";

--- a/CCSwitcher/fr.lproj/Localizable.strings
+++ b/CCSwitcher/fr.lproj/Localizable.strings
@@ -130,6 +130,8 @@
 "Could not capture credentials" = "Impossible de récupérer les identifiants";
 "No stored credentials for %@. Use re-authenticate to fix." = "Aucun identifiant enregistré pour %@. Utilisez la réauthentification pour corriger.";
 "Logged in as %@, but expected %@. Credentials not updated." = "Connecté en tant que %1$@, mais %2$@ était attendu. Identifiants non mis à jour.";
+"Claude CLI is authenticating via %@ instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again." = "Claude CLI s'authentifie via %@ au lieu d'une connexion claude.ai enregistrée et ne signale donc aucun compte. Supprimez ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE ainsi que tout apiKeyHelper, puis réessayez.";
+"Switched to %@, but the Claude CLI is authenticating via %@ instead of the stored login, so it will not use this account." = "Basculé vers %1$@, mais Claude CLI s'authentifie via %2$@ au lieu de la connexion enregistrée et n'utilisera donc pas ce compte.";
 "Token expired. Switch to refresh." = "Jeton expiré. Basculez pour actualiser.";
 "Token expired. Switch to this account to refresh." = "Jeton expiré. Basculez vers ce compte pour actualiser.";
 "API Rate Limited. Try again later." = "Limite de l'API atteinte. Réessayez plus tard.";

--- a/CCSwitcher/ja.lproj/Localizable.strings
+++ b/CCSwitcher/ja.lproj/Localizable.strings
@@ -130,6 +130,8 @@
 "Could not capture credentials" = "認証情報を取得できませんでした";
 "No stored credentials for %@. Use re-authenticate to fix." = "%@ の保存済み認証情報がありません。再認証で修復してください。";
 "Logged in as %@, but expected %@. Credentials not updated." = "%1$@ としてログインしましたが、%2$@ が期待されていました。認証情報は更新されません。";
+"Claude CLI is authenticating via %@ instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again." = "Claude CLI は保存された claude.ai ログインではなく %@ で認証しているため、アカウントを報告しません。ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE を解除し、apiKeyHelper があれば削除してから、もう一度お試しください。";
+"Switched to %@, but the Claude CLI is authenticating via %@ instead of the stored login, so it will not use this account." = "%1$@ に切り替えましたが、Claude CLI は保存されたログインではなく %2$@ で認証しているため、このアカウントは使用されません。";
 "Token expired. Switch to refresh." = "トークンが期限切れです。切り替えて更新してください。";
 "Token expired. Switch to this account to refresh." = "トークンが期限切れです。このアカウントに切り替えて更新してください。";
 "API Rate Limited. Try again later." = "API レート制限中。後でもう一度お試しください。";

--- a/CCSwitcher/zh-Hans.lproj/Localizable.strings
+++ b/CCSwitcher/zh-Hans.lproj/Localizable.strings
@@ -130,6 +130,8 @@
 "Could not capture credentials" = "无法获取凭据";
 "No stored credentials for %@. Use re-authenticate to fix." = "没有 %@ 的存储凭据。请使用重新认证来修复。";
 "Logged in as %@, but expected %@. Credentials not updated." = "登录账户为 %1$@，但预期为 %2$@。凭据未更新。";
+"Claude CLI is authenticating via %@ instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again." = "Claude CLI 正在通过 %@ 进行认证，而不是使用已保存的 claude.ai 登录，因此不会报告账号。请取消 ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE，并移除所有 apiKeyHelper，然后重试。";
+"Switched to %@, but the Claude CLI is authenticating via %@ instead of the stored login, so it will not use this account." = "已切换到 %1$@，但 Claude CLI 正在通过 %2$@ 认证，而不是使用已保存的登录，因此不会使用此账号。";
 "Token expired. Switch to refresh." = "令牌已过期。切换以刷新。";
 "Token expired. Switch to this account to refresh." = "令牌已过期。切换到此账户以刷新。";
 "API Rate Limited. Try again later." = "API 请求频率受限。请稍后重试。";


### PR DESCRIPTION
Fixes #18.

## Symptom

Since Claude Code 2.1.x, switching accounts intermittently fails with

```
Switch failed: expected <email> but got unknown. Try removing and re-adding the account.
```

Removing and re-adding, or a full `claude auth login`, does not help — because nothing is actually wrong with the credentials. The swap succeeds; only the verification step misreads it.

## Root cause

`claude auth status` only emits `email`, `orgId`, `orgName` and `subscriptionType` when `authMethod == "claude.ai"` — i.e. when the stored claude.ai login is the credential source the CLI actually resolves to. From the 2.1.220 bundle:

```js
let m = { loggedIn: c, authMethod: u, apiProvider: p };
…
if (u === "claude.ai") {
  m.email = s?.emailAddress ?? null;
  m.orgId = s?.organizationUuid ?? null;
  m.orgName = s?.organizationName ?? null;
  m.subscriptionType = a ?? null;
}
```

Any higher-precedence credential source shadows the stored login and the whole identity block is omitted, while `loggedIn` stays `true`: `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, an `apiKeyHelper`, an OAuth token file, an Anthropic profile in `~/.config/anthropic`, or a third-party provider (Bedrock/Vertex/…).

Step 4 of `switchAccount` compared that *missing* field against the target email:

```swift
if status.email != targetAccount.email {
    throw ClaudeServiceError.switchWrongAccount(expected: targetAccount.email,
                                                actual: status.email ?? "unknown")
}
```

`nil != "b@example.com"` → the switch is reported as a wrong-account failure, with `actual: "unknown"`. Hence the exact wording users are seeing.

### Evidence from an affected machine

`CCSwitcher-app.log`, three switches in a row. `claude auth status` returns 85 bytes (no identity block) while the swap itself is demonstrably correct — the live keychain token and `~/.claude.json` both already hold the target account:

```
[03:15:32.137] [Keychain] [readClaudeToken] Found via security CLI, length=982   ← target's token
[03:15:32.146] [Keychain] [readOAuthAccount] Found: email=ynotsafe313@gmail.com  ← target's identity
…
[03:16:00.186] [Keychain] [writeClaudeToken] Result: true
[03:16:00.193] [Keychain] [writeOAuthAccount] Written: email=ynotsafe313@gmail.com
[03:16:00.193] [Claude]   [switchAccount] Step 3: Both token and oauthAccount written
[03:16:00.382] [Claude]   [runClaude] Success (exit 0), output length: 85
[03:16:00.382] [Claude]   [getAuthStatus] loggedIn=true, provider=firstParty, sub=nil
[03:16:00.382] [Claude]   [switchAccount] Step 4: Logged in as nil instead of ynotsafe313@gmail.com
[03:16:00.382] [AppState] [switchTo] Switch failed: Switch failed: expected ynotsafe313@gmail.com but got unknown.
```

85 bytes is exactly `{ loggedIn, authMethod, apiProvider }` with `authMethod: "oauth_token"`. It also toggles independently of CCSwitcher — the same log shows 254-byte (identity present) and 85-byte responses alternating across refreshes with no switch in between, which is why the bug looks random and why re-authorizing never fixes it.

## The fix

Verification now distinguishes "identity unavailable" from "a different account is active":

- **`email` present and different** → still a real mismatch, unchanged error.
- **`email` absent** → verify against ground truth CCSwitcher owns instead of trusting a field the CLI declined to emit: the live keychain `accessToken` must equal the target backup's, and the `~/.claude.json` identity must be the target email. On match the switch succeeds and the user gets a warning naming the shadowing credential source; on mismatch it still fails with `switchVerificationFailed`.

The same missing field made `addAccount`, `loginNewAccount` and `reauthenticateAccount` report "Not logged in to Claude" / "Login did not complete" while the CLI was in fact authenticated — which is what pushes users into the pointless re-authorization loop. They now report the shadowing source and what to unset.

## Changes

- `Models/Account.swift` — document the `auth status` contract; add `AuthStatus.reportsClaudeAiIdentity` and `.shadowingAuthMethod`.
- `Services/ClaudeService.swift` — `switchAccount` returns a `SwitchOutcome`; local `credentialsOnDiskMatch(backup:email:)` fallback verification.
- `AppState.swift` — surface the warning after a shadowed switch; `shadowedIdentityMessage(_:)` replaces the misleading "not logged in" messages in the three login/add/reauth paths.
- `ARCHITECTURE.md` — Step 4 of the switch flow updated with the new branch and the CLI contract.
- `en/de/fr/ja/zh-Hans.lproj/Localizable.strings` — two new strings, all five languages.

## Verification

- `swiftc -typecheck` over `AppState.swift`, `Models/*.swift` and `Services/*.swift` (excluding the Sparkle- and View-dependent files, which need the full Xcode toolchain): clean.
- `plutil -lint` on all five `Localizable.strings`: OK.
- No behaviour change on the happy path: a switch where `claude auth status` reports the expected email takes the identical code path as before.

I don't have full Xcode on this machine, so the app target itself wasn't built — a CI run should cover that.
