### PR TITLE
fix: support multiple organizations under the same account email

### DIFF
--- a/CCSwitcher/AppState.swift
+++ b/CCSwitcher/AppState.swift
@@ -201,6 +201,18 @@ final class AppState: ObservableObject {
 
     // MARK: - Account Management
 
+    /// Locate an account by (email, orgId). The same email can belong to
+    /// multiple Teams/organizations, so matching by email alone would let a
+    /// second organization silently take over the first one's entry.
+    /// Accounts saved by older versions have no orgId (nil): fall back to
+    /// email-only matching for those; callers backfill orgId after matching.
+    private func matchAccountIndex(email: String, orgId: String?) -> Int? {
+        if let exact = accounts.firstIndex(where: { $0.email == email && $0.orgId == orgId }) {
+            return exact
+        }
+        return accounts.firstIndex(where: { $0.email == email && $0.orgId == nil })
+    }
+
     func addAccount() async {
         log.info("[addAccount] Starting add current account flow...")
         guard claudeAvailable else {
@@ -223,9 +235,11 @@ final class AppState: ObservableObject {
             }
             log.info("[addAccount] Current auth: logged in, sub=\(status.subscriptionType ?? "nil")")
 
-            if accounts.contains(where: { $0.email == email }) {
+            if let existing = matchAccountIndex(email: email, orgId: status.orgId) {
+                accounts[existing].orgId = status.orgId // Backfill for accounts saved by older versions
+                saveAccounts()
                 errorMessage = String(localized: "Account already exists", bundle: L10n.bundle)
-                log.warning("[addAccount] Aborted: duplicate account")
+                log.warning("[addAccount] Aborted: duplicate account (same email + org)")
                 return
             }
 
@@ -234,6 +248,7 @@ final class AppState: ObservableObject {
                 displayName: status.orgName ?? email,
                 provider: .claudeCode,
                 orgName: status.orgName,
+                orgId: status.orgId,
                 subscriptionType: status.subscriptionType,
                 isActive: accounts.isEmpty
             )
@@ -321,12 +336,13 @@ final class AppState: ObservableObject {
             // using. The capture CAN also fail (e.g. the backup store refuses
             // writes while unreadable); claiming "credentials refreshed" then
             // would leave a stale backup behind an explicit success message.
-            if let existing = accounts.firstIndex(where: { $0.email == email }) {
-                log.info("[loginNewAccount] Step 4: Account already exists, refreshing backup and marking it active")
+            if let existing = matchAccountIndex(email: email, orgId: status.orgId) {
+                log.info("[loginNewAccount] Step 4: Account already exists (email + org), refreshing backup and marking it active")
                 let captured = claudeService.captureCurrentCredentials(forAccountId: accounts[existing].id.uuidString)
                 for i in accounts.indices {
                     accounts[i].isActive = (i == existing)
                 }
+                accounts[existing].orgId = status.orgId // Backfill for accounts saved by older versions
                 accounts[existing].lastUsed = Date()
                 activeAccount = accounts[existing]
                 // A login is a deliberate account choice; grant it the same
@@ -349,6 +365,7 @@ final class AppState: ObservableObject {
                 displayName: status.orgName ?? email,
                 provider: .claudeCode,
                 orgName: status.orgName,
+                orgId: status.orgId,
                 subscriptionType: status.subscriptionType,
                 isActive: true
             )
@@ -679,6 +696,16 @@ final class AppState: ObservableObject {
                 return
             }
 
+            // The same email can belong to multiple organizations: make sure the
+            // login landed on THIS entry's organization, so another Team's
+            // credentials don't get stored under it.
+            if let expectedOrg = account.orgId, let gotOrg = status.orgId, expectedOrg != gotOrg {
+                errorMessage = String(localized: "Logged in to organization \(status.orgName ?? gotOrg), but expected \(account.orgName ?? expectedOrg). Credentials not updated.", bundle: L10n.bundle)
+                log.error("[reauth] Org mismatch: got \(gotOrg), expected \(expectedOrg)")
+                isLoggingIn = false
+                return
+            }
+
             // 4. Capture the fresh token
             let captured = claudeService.captureCurrentCredentials(forAccountId: account.id.uuidString)
             log.info("[reauth] Token capture result: \(captured)")
@@ -690,6 +717,7 @@ final class AppState: ObservableObject {
             // fail while the UI claimed everything was refreshed.
             if let index = accounts.firstIndex(where: { $0.id == account.id }) {
                 accounts[index].orgName = status.orgName
+                accounts[index].orgId = status.orgId // Backfill for accounts saved by older versions
                 accounts[index].subscriptionType = status.subscriptionType
 
                 // Mark this account as active (it's what the CLI is now using)
@@ -1065,11 +1093,12 @@ final class AppState: ObservableObject {
     private func updateActiveAccount(from status: AuthStatus) {
         guard status.loggedIn, let email = status.email else { return }
 
-        if let index = accounts.firstIndex(where: { $0.email == email }) {
+        if let index = matchAccountIndex(email: email, orgId: status.orgId) {
             for i in accounts.indices {
                 accounts[i].isActive = (i == index)
             }
             accounts[index].orgName = status.orgName
+            accounts[index].orgId = status.orgId // Backfill for accounts saved by older versions
             accounts[index].subscriptionType = status.subscriptionType
             activeAccount = accounts[index]
             saveAccounts()
@@ -1080,6 +1109,7 @@ final class AppState: ObservableObject {
                 displayName: status.orgName ?? email,
                 provider: .claudeCode,
                 orgName: status.orgName,
+                orgId: status.orgId,
                 subscriptionType: status.subscriptionType,
                 isActive: true
             )

--- a/CCSwitcher/Models/Account.swift
+++ b/CCSwitcher/Models/Account.swift
@@ -34,6 +34,11 @@ struct Account: Identifiable, Codable, Hashable {
     var displayName: String
     var provider: AIProviderType
     var orgName: String?
+    /// Organization ID. One email can belong to multiple Teams/organizations,
+    /// so account identity must be the (email, orgId) composite key.
+    /// Accounts saved by older versions decode this as nil; matching falls
+    /// back to email-only for those and backfills the value afterwards.
+    var orgId: String?
     var subscriptionType: String?
     var isActive: Bool
     var lastUsed: Date?
@@ -87,6 +92,7 @@ struct Account: Identifiable, Codable, Hashable {
         displayName: String,
         provider: AIProviderType = .claudeCode,
         orgName: String? = nil,
+        orgId: String? = nil,
         subscriptionType: String? = nil,
         isActive: Bool = false,
         lastUsed: Date? = nil,
@@ -97,6 +103,7 @@ struct Account: Identifiable, Codable, Hashable {
         self.displayName = displayName
         self.provider = provider
         self.orgName = orgName
+        self.orgId = orgId
         self.subscriptionType = subscriptionType
         self.isActive = isActive
         self.lastUsed = lastUsed

--- a/CCSwitcher/Views/UsageDashboardView.swift
+++ b/CCSwitcher/Views/UsageDashboardView.swift
@@ -57,7 +57,7 @@ struct UsageDashboardView: View {
                     // Today's activity stats
                     todayActivityCard
 
-                    ForEach(appState.accounts) { account in
+                    ForEach(accountsActiveFirst) { account in
                         accountUsageCard(account: account, usage: appState.accountUsage[account.id])
                     }
                 }
@@ -199,6 +199,22 @@ struct UsageDashboardView: View {
 
     // MARK: - Per-Account Card
 
+    /// Active account first: the card you're actually spending from should be
+    /// the top one, not something you have to hunt for. Sorting is made stable
+    /// by falling back to the stored order, so the list never reshuffles on a
+    /// refresh. Only the Usage tab reorders — the Accounts tab keeps the stored
+    /// order so managing accounts doesn't move rows under the cursor.
+    private var accountsActiveFirst: [Account] {
+        appState.accounts.enumerated()
+            .sorted { lhs, rhs in
+                if lhs.element.isActive != rhs.element.isActive {
+                    return lhs.element.isActive
+                }
+                return lhs.offset < rhs.offset
+            }
+            .map(\.element)
+    }
+
     private func accountUsageCard(account: Account, usage: UsageAPIResponse?) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             accountHeader(account)
@@ -232,7 +248,10 @@ struct UsageDashboardView: View {
                 .padding(.top, 4)
             }
         }
-        .cardStyle(fill: account.isActive ? .cardFill : .cardFill)
+        // The active card is marked by position (first), the "Active" badge and
+        // a slightly heavier fill — deliberately no accent border, which read as
+        // an out-of-place box against the flat cards around it.
+        .cardStyle(fill: account.isActive ? .cardFillStrong : .cardFill)
         .sectionPadding()
     }
 
@@ -256,17 +275,37 @@ struct UsageDashboardView: View {
 
     @ViewBuilder
     private func accountHeader(_ account: Account) -> some View {
+        // One email can belong to several organizations/Teams, so the email
+        // alone makes those cards indistinguishable. Lead with the org name
+        // (or custom label) and keep the email as a subtitle, matching the
+        // popover header and the Accounts tab. The subtitle is dropped when the
+        // name already IS the email (no org, no label) so single-org cards keep
+        // their original one-line height instead of repeating themselves.
+        let name = account.effectiveDisplayName(obfuscated: !showFullEmail)
+        let email = account.displayEmail(obfuscated: !showFullEmail)
+
         HStack(spacing: 8) {
             Image(systemName: account.provider.iconName)
                 .font(.subheadline)
                 .foregroundStyle(account.isActive ? .brand : .secondary)
 
-            Text(account.displayEmail(obfuscated: !showFullEmail))
-                .font(.subheadline.weight(.medium))
-                .lineLimit(1)
+            VStack(alignment: .leading, spacing: 1) {
+                HStack(spacing: 6) {
+                    Text(name)
+                        .font(.subheadline.weight(account.isActive ? .semibold : .medium))
+                        .lineLimit(1)
 
-            if account.isActive {
-                Badge(text: String(localized: "Active", bundle: L10n.bundle), color: .green)
+                    if account.isActive {
+                        Badge(text: String(localized: "Active", bundle: L10n.bundle), color: .green)
+                    }
+                }
+
+                if name != email {
+                    Text(email)
+                        .font(.caption2)
+                        .foregroundStyle(.textSecondary)
+                        .lineLimit(1)
+                }
             }
 
             Spacer()

--- a/CCSwitcher/de.lproj/Localizable.strings
+++ b/CCSwitcher/de.lproj/Localizable.strings
@@ -131,6 +131,7 @@
 "Could not capture credentials" = "Anmeldedaten konnten nicht erfasst werden";
 "No stored credentials for %@. Use re-authenticate to fix." = "Keine gespeicherten Anmeldedaten für %@. Verwenden Sie Erneut authentifizieren zur Behebung.";
 "Logged in as %@, but expected %@. Credentials not updated." = "Angemeldet als %1$@, aber %2$@ erwartet. Anmeldedaten nicht aktualisiert.";
+"Logged in to organization %@, but expected %@. Credentials not updated." = "Bei Organisation %1$@ angemeldet, aber %2$@ erwartet. Anmeldedaten nicht aktualisiert.";
 "Claude CLI is authenticating via %@ instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again." = "Die Claude CLI authentifiziert sich über %@ statt über eine gespeicherte claude.ai-Anmeldung und meldet daher kein Konto. Heben Sie ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE auf, entfernen Sie einen etwaigen apiKeyHelper und versuchen Sie es erneut.";
 "Switched to %@, but the Claude CLI is authenticating via %@ instead of the stored login, so it will not use this account." = "Zu %1$@ gewechselt, aber die Claude CLI authentifiziert sich über %2$@ statt über die gespeicherte Anmeldung und verwendet dieses Konto daher nicht.";
 "Token expired. Switch to refresh." = "Token abgelaufen. Wechseln zum Aktualisieren.";

--- a/CCSwitcher/en.lproj/Localizable.strings
+++ b/CCSwitcher/en.lproj/Localizable.strings
@@ -131,6 +131,7 @@
 "Could not capture credentials" = "Could not capture credentials";
 "No stored credentials for %@. Use re-authenticate to fix." = "No stored credentials for %@. Use re-authenticate to fix.";
 "Logged in as %@, but expected %@. Credentials not updated." = "Logged in as %1$@, but expected %2$@. Credentials not updated.";
+"Logged in to organization %@, but expected %@. Credentials not updated." = "Logged in to organization %1$@, but expected %2$@. Credentials not updated.";
 "Claude CLI is authenticating via %@ instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again." = "Claude CLI is authenticating via %@ instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again.";
 "Switched to %@, but the Claude CLI is authenticating via %@ instead of the stored login, so it will not use this account." = "Switched to %1$@, but the Claude CLI is authenticating via %2$@ instead of the stored login, so it will not use this account.";
 "Token expired. Switch to refresh." = "Token expired. Switch to refresh.";

--- a/CCSwitcher/fr.lproj/Localizable.strings
+++ b/CCSwitcher/fr.lproj/Localizable.strings
@@ -131,6 +131,7 @@
 "Could not capture credentials" = "Impossible de récupérer les identifiants";
 "No stored credentials for %@. Use re-authenticate to fix." = "Aucun identifiant enregistré pour %@. Utilisez la réauthentification pour corriger.";
 "Logged in as %@, but expected %@. Credentials not updated." = "Connecté en tant que %1$@, mais %2$@ était attendu. Identifiants non mis à jour.";
+"Logged in to organization %@, but expected %@. Credentials not updated." = "Connecté à l'organisation %1$@, mais %2$@ était attendue. Identifiants non mis à jour.";
 "Claude CLI is authenticating via %@ instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again." = "Claude CLI s'authentifie via %@ au lieu d'une connexion claude.ai enregistrée et ne signale donc aucun compte. Supprimez ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE ainsi que tout apiKeyHelper, puis réessayez.";
 "Switched to %@, but the Claude CLI is authenticating via %@ instead of the stored login, so it will not use this account." = "Basculé vers %1$@, mais Claude CLI s'authentifie via %2$@ au lieu de la connexion enregistrée et n'utilisera donc pas ce compte.";
 "Token expired. Switch to refresh." = "Jeton expiré. Basculez pour actualiser.";

--- a/CCSwitcher/ja.lproj/Localizable.strings
+++ b/CCSwitcher/ja.lproj/Localizable.strings
@@ -131,6 +131,7 @@
 "Could not capture credentials" = "認証情報を取得できませんでした";
 "No stored credentials for %@. Use re-authenticate to fix." = "%@ の保存済み認証情報がありません。再認証で修復してください。";
 "Logged in as %@, but expected %@. Credentials not updated." = "%1$@ としてログインしましたが、%2$@ が期待されていました。認証情報は更新されません。";
+"Logged in to organization %@, but expected %@. Credentials not updated." = "組織 %1$@ にログインしましたが、%2$@ が期待されていました。認証情報は更新されません。";
 "Claude CLI is authenticating via %@ instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again." = "Claude CLI は保存された claude.ai ログインではなく %@ で認証しているため、アカウントを報告しません。ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE を解除し、apiKeyHelper があれば削除してから、もう一度お試しください。";
 "Switched to %@, but the Claude CLI is authenticating via %@ instead of the stored login, so it will not use this account." = "%1$@ に切り替えましたが、Claude CLI は保存されたログインではなく %2$@ で認証しているため、このアカウントは使用されません。";
 "Token expired. Switch to refresh." = "トークンが期限切れです。切り替えて更新してください。";

--- a/CCSwitcher/zh-Hans.lproj/Localizable.strings
+++ b/CCSwitcher/zh-Hans.lproj/Localizable.strings
@@ -131,6 +131,7 @@
 "Could not capture credentials" = "无法获取凭据";
 "No stored credentials for %@. Use re-authenticate to fix." = "没有 %@ 的存储凭据。请使用重新认证来修复。";
 "Logged in as %@, but expected %@. Credentials not updated." = "登录账户为 %1$@，但预期为 %2$@。凭据未更新。";
+"Logged in to organization %@, but expected %@. Credentials not updated." = "登录组织为 %1$@，但预期为 %2$@。凭据未更新。";
 "Claude CLI is authenticating via %@ instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again." = "Claude CLI 正在通过 %@ 进行认证，而不是使用已保存的 claude.ai 登录，因此不会报告账号。请取消 ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE，并移除所有 apiKeyHelper，然后重试。";
 "Switched to %@, but the Claude CLI is authenticating via %@ instead of the stored login, so it will not use this account." = "已切换到 %1$@，但 Claude CLI 正在通过 %2$@ 认证，而不是使用已保存的登录，因此不会使用此账号。";
 "Token expired. Switch to refresh." = "令牌已过期。切换以刷新。";


### PR DESCRIPTION
## Problem

One claude.ai account can belong to several Team/Enterprise organizations. CCSwitcher deduplicates accounts by **email alone**, so a user who logs in to a second organization of the same account and clicks *Add Account* gets **"Account already exists - credentials refreshed"** — and the first organization's credential backup is overwritten instead of a second entry being created. Multi-org accounts therefore can't be managed at all.

There is a related hidden bug: `updateActiveAccount(from:)` also matches by email, so when the CLI is logged in to a sibling organization it rewrites the *other* organization's entry (its `orgName` and active flag).

## Fix

Account identity becomes the **(email, orgId) composite key**. `orgId` comes from `AuthStatus.orgId`, which `claude auth status` already reports — the model just never stored it.

- `Account` gains an optional `orgId` field. Entries saved by older versions decode it as `nil`; a new `matchAccountIndex(email:orgId:)` helper falls back to email-only matching for those and call sites backfill the value, so existing users migrate transparently.
- `addAccount`, `loginNewAccount` and `updateActiveAccount` all match via the composite key.
- `reauth` additionally verifies the login landed on the entry's organization, so renewing one org's entry can't silently store a sibling org's credentials under it (same email would previously pass the check). New error string added to all five localizations.

No storage migration is needed: credential backups were already keyed by the app-generated account UUID.

## Testing

- Built and ran locally (Xcode 26.6, macOS 26.5).
- Real-world verification with one account in two Team organizations: *Add Account* now creates a second entry (previously overwrote), both entries show their own org name and usage, switching between them works, and `updateActiveAccount` no longer cross-writes entries after a switch.
- Legacy path: an entry created before the patch (no `orgId`) was matched by the email fallback and backfilled on first refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)