### PR TITLE
fix: attribute the live credential by anchor, not by ~/.claude.json (#25)

### DIFF
--- a/CCSwitcher/AppState.swift
+++ b/CCSwitcher/AppState.swift
@@ -46,6 +46,11 @@ final class AppState: ObservableObject {
     private let activityParser = ActivityParser.shared
     private let keychain = KeychainService.shared
 
+    /// Ties the live keychain credential to the account that owns it, so
+    /// neither usage attribution nor a backup has to trust `~/.claude.json`'s
+    /// identity block — which any running Claude Code session can rewrite.
+    private let credentialAnchor = CredentialAnchorStore()
+
     private let accountsKey = "com.ccswitcher.accounts"
     private var refreshTimer: Timer?
 
@@ -199,6 +204,44 @@ final class AppState: ObservableObject {
         refreshTimer = nil
     }
 
+    // MARK: - Credential ownership
+
+    /// Who the credential currently in the keychain belongs to.
+    ///
+    /// Every read of the live credential goes through this: `~/.claude.json`
+    /// naming an account is not evidence that the token beside it is that
+    /// account's, and acting as though it were is what filed one account's
+    /// usage on another's card and overwrote its stored token.
+    private func liveCredentialOwner() -> LiveCredentialOwner {
+        let accessToken = keychain.readClaudeToken().flatMap(ClaudeService.extractAccessToken(from:))
+        let claimedEmail = keychain.readOAuthAccount()?["emailAddress"]?.value as? String
+        let claimedId = claimedEmail.flatMap { email in accounts.first(where: { $0.email == email })?.id }
+        return credentialAnchor.resolveOwner(accessToken: accessToken, claimedAccountId: claimedId)
+    }
+
+    /// Record that the live credential is `accountId`'s. Only for the moments
+    /// CCSwitcher established that itself — a completed switch, login, re-auth
+    /// or capture — never on the identity block's say-so.
+    private func anchorLiveCredential(to accountId: UUID) {
+        guard let tokenJSON = keychain.readClaudeToken(),
+              let accessToken = ClaudeService.extractAccessToken(from: tokenJSON) else { return }
+        credentialAnchor.anchor(accountId: accountId, accessToken: accessToken)
+    }
+
+    /// Back up the live credential as `account`'s, but only when it really is.
+    /// Storing it otherwise overwrites one account's saved token with another's,
+    /// which survives every later switch and silently spends the wrong quota.
+    @discardableResult
+    private func captureLiveCredential(as account: Account) -> Bool {
+        guard liveCredentialOwner().credentialAccountId == account.id else {
+            log.warning("[capture] Live credential is not confirmed to be \(account.email)'s; skipping backup rather than storing it under the wrong account")
+            return false
+        }
+        let captured = claudeService.captureCurrentCredentials(forAccountId: account.id.uuidString)
+        if captured { anchorLiveCredential(to: account.id) }
+        return captured
+    }
+
     // MARK: - Account Management
 
     func addAccount() async {
@@ -229,6 +272,16 @@ final class AppState: ObservableObject {
                 return
             }
 
+            // The CLI reports the identity block, which can name an account the
+            // live token does not belong to. Adding on that word would file
+            // another account's credential under a brand-new entry.
+            if let ownerId = liveCredentialOwner().credentialAccountId,
+               let owner = accounts.first(where: { $0.id == ownerId }), owner.email != email {
+                errorMessage = String(localized: "Claude reports \(email), but the stored sign-in still belongs to \(owner.email). Switch accounts once, then add.", bundle: L10n.bundle)
+                log.error("[addAccount] Aborted: live credential belongs to \(owner.email), not \(email)")
+                return
+            }
+
             var account = Account(
                 email: email,
                 displayName: status.orgName ?? email,
@@ -247,6 +300,7 @@ final class AppState: ObservableObject {
                 return
             }
             log.info("[addAccount] Token captured successfully")
+            anchorLiveCredential(to: account.id)
 
             if accounts.isEmpty {
                 account.isActive = true
@@ -286,7 +340,7 @@ final class AppState: ObservableObject {
             // 1. Back up current account (token + oauthAccount) before login overwrites them
             if let current = activeAccount {
                 log.info("[loginNewAccount] Step 1: Backing up current account (\(current.email))...")
-                let backed = claudeService.captureCurrentCredentials(forAccountId: current.id.uuidString)
+                let backed = captureLiveCredential(as: current)
                 log.info("[loginNewAccount] Step 1: Backup result: \(backed)")
             } else {
                 log.info("[loginNewAccount] Step 1: No active account, skipping backup")
@@ -323,7 +377,11 @@ final class AppState: ObservableObject {
             // would leave a stale backup behind an explicit success message.
             if let existing = accounts.firstIndex(where: { $0.email == email }) {
                 log.info("[loginNewAccount] Step 4: Account already exists, refreshing backup and marking it active")
+                // A just-completed login is itself the proof of ownership — the
+                // CLI minted this credential for this account — so capture and
+                // re-anchor directly instead of asking the (now superseded) anchor.
                 let captured = claudeService.captureCurrentCredentials(forAccountId: accounts[existing].id.uuidString)
+                if captured { anchorLiveCredential(to: accounts[existing].id) }
                 for i in accounts.indices {
                     accounts[i].isActive = (i == existing)
                 }
@@ -361,6 +419,7 @@ final class AppState: ObservableObject {
                 isLoggingIn = false
                 return
             }
+            anchorLiveCredential(to: account.id)
 
             // 6. Mark new account as active
             for i in accounts.indices {
@@ -399,6 +458,7 @@ final class AppState: ObservableObject {
     func removeAccount(_ account: Account) {
         log.info("[removeAccount] Removing account \(account.id)")
         keychain.removeAccountBackup(forAccountId: account.id.uuidString)
+        credentialAnchor.forget(accountId: account.id)
         accounts.removeAll { $0.id == account.id }
         // Drop every per-account cache too, or a re-added account inherits the
         // removed one's readings, error banner and rate-limit park.
@@ -459,9 +519,19 @@ final class AppState: ObservableObject {
         // auto-switched away from it seconds later by the refresh that follows.
         lastAutoSwitchAt = Date()
 
+        // Whether the credential about to be backed up really is the outgoing
+        // account's. Resolved here, where the account list lives, and handed
+        // down for the same reason `targetBackup` is: the switch must not
+        // re-derive it from the identity block one layer lower.
+        let liveCredentialIsSource = liveCredentialOwner().credentialAccountId == currentActive.id
+
         isLoading = true
         do {
-            let outcome = try await claudeService.switchAccount(from: currentActive, to: account, targetBackup: targetBackup)
+            let outcome = try await claudeService.switchAccount(from: currentActive, to: account, targetBackup: targetBackup, liveCredentialIsSource: liveCredentialIsSource)
+
+            // CCSwitcher just wrote this credential for this account — the one
+            // moment the pairing is known first-hand rather than inferred.
+            anchorLiveCredential(to: account.id)
 
             for i in accounts.indices {
                 accounts[i].isActive = (accounts[i].id == account.id)
@@ -593,6 +663,14 @@ final class AppState: ObservableObject {
             return nil
         }
 
+        // Same rule as the polling loop: the live credential may only stand in
+        // for the account it actually belongs to. Auto-switch verifies against
+        // this reading, so a misattributed one would swap on the wrong quota.
+        if account.isActive, liveCredentialOwner().credentialAccountId != account.id {
+            log.warning("[fetchUsageNow] Live credential is not confirmed to be \(account.email)'s; no reading available")
+            return nil
+        }
+
         let tokenJSON = account.isActive
             ? keychain.readClaudeToken()
             : keychain.getAccountBackup(forAccountId: account.id.uuidString)?.token
@@ -651,7 +729,7 @@ final class AppState: ObservableObject {
             // 1. Back up current active account before login overwrites it
             if let current = activeAccount, current.id != account.id {
                 log.info("[reauth] Backing up current account before login...")
-                _ = claudeService.captureCurrentCredentials(forAccountId: current.id.uuidString)
+                captureLiveCredential(as: current)
             }
 
             // 2. Run login
@@ -679,8 +757,11 @@ final class AppState: ObservableObject {
                 return
             }
 
-            // 4. Capture the fresh token
+            // 4. Capture the fresh token. The login just proved this credential
+            // is this account's, so it also re-anchors — this is the way out of
+            // a desync the user is told to take.
             let captured = claudeService.captureCurrentCredentials(forAccountId: account.id.uuidString)
+            if captured { anchorLiveCredential(to: account.id) }
             log.info("[reauth] Token capture result: \(captured)")
 
             // 5. Update account metadata. Done even when the capture failed —
@@ -860,6 +941,13 @@ final class AppState: ObservableObject {
 
         // For active account: use live keychain token (with delegated refresh on expiry)
         // For other accounts: use backup token (refreshed in place when expired)
+        //
+        // Resolved once per cycle: the live credential belongs to exactly one
+        // account, and only that account's card may be filled from it. Reading
+        // it for whoever the identity block currently names is what put one
+        // account's percentages on the other's card for hours.
+        let liveCredentialOwnerId = liveCredentialOwner().credentialAccountId
+
         var isFirstRequest = true
         for account in targets {
             // Stagger requests: a back-to-back burst (one request per account within
@@ -871,6 +959,11 @@ final class AppState: ObservableObject {
 
             let tokenJSON: String?
             if account.isActive {
+                guard liveCredentialOwnerId == account.id else {
+                    log.warning("[fetchUsage] Live credential is not confirmed to be \(account.email)'s; taking no reading rather than filing someone else's")
+                    accountUsageErrors[account.id] = UsageErrorState(isExpired: false, isRateLimited: false, message: String(localized: "Can't tell which account the current sign-in belongs to. Switch accounts once to re-sync.", bundle: L10n.bundle))
+                    continue
+                }
                 tokenJSON = keychain.readClaudeToken()
             } else {
                 tokenJSON = keychain.getAccountBackup(forAccountId: account.id.uuidString)?.token
@@ -911,14 +1004,20 @@ final class AppState: ObservableObject {
                     do {
                         _ = try await claudeService.getAuthStatus()
                         log.info("[fetchUsage] Delegated refresh completed for active account.")
-                        // Re-read refreshed token and retry
+                        // Re-read refreshed token and retry. A refresh rotates the
+                        // credential in place without changing whose it is, so
+                        // re-anchor to the same account — otherwise the anchor
+                        // goes stale and the next cycle falls back to believing
+                        // the identity block again.
                         if let refreshedJSON = keychain.readClaudeToken(),
-                           let refreshedToken = ClaudeService.extractAccessToken(from: refreshedJSON),
-                           let usage = await usageRespectingParking(accessToken: refreshedToken, account: account) {
-                            accountUsage[account.id] = usage
-                            accountUsageSampledAt[account.id] = Date()
-                            accountUsageErrors[account.id] = nil
-                            log.info("[fetchUsage] Recovered \(account.email) via delegated refresh.")
+                           let refreshedToken = ClaudeService.extractAccessToken(from: refreshedJSON) {
+                            credentialAnchor.anchor(accountId: account.id, accessToken: refreshedToken)
+                            if let usage = await usageRespectingParking(accessToken: refreshedToken, account: account) {
+                                accountUsage[account.id] = usage
+                                accountUsageSampledAt[account.id] = Date()
+                                accountUsageErrors[account.id] = nil
+                                log.info("[fetchUsage] Recovered \(account.email) via delegated refresh.")
+                            }
                         }
                     } catch {
                         log.error("[fetchUsage] Delegated refresh failed for active account: \(error.localizedDescription)")
@@ -989,6 +1088,19 @@ final class AppState: ObservableObject {
             log.info("[diagnose] Live oauthAccount: \(liveEmail)")
         } else {
             log.warning("[diagnose] Live oauthAccount: MISSING")
+        }
+
+        // The identity block above says who is signed in; this says whose
+        // credential is actually sitting next to it. When they disagree, every
+        // number on the cards is suspect — say so here rather than leaving it
+        // to be reconstructed from percentages later.
+        switch liveCredentialOwner() {
+        case .owned(let id):
+            log.info("[diagnose] Live credential belongs to: \(self.accounts.first(where: { $0.id == id })?.email ?? id.uuidString)")
+        case .desynced(_, let credential):
+            log.warning("[diagnose] DESYNCED: identity block and live credential disagree; credential is \(self.accounts.first(where: { $0.id == credential })?.email ?? credential.uuidString)'s")
+        case .unknown:
+            log.warning("[diagnose] Live credential owner: UNKNOWN")
         }
 
         // Check each account has a backup
@@ -1065,6 +1177,23 @@ final class AppState: ObservableObject {
     private func updateActiveAccount(from status: AuthStatus) {
         guard status.loggedIn, let email = status.email else { return }
 
+        // The CLI reports the identity block, so when that block has been
+        // rewritten out from under the credential it names the wrong account.
+        // Every API call is billed against the credential, so the active badge
+        // belongs to its owner — following the block here is what made the app
+        // claim the other account was in use while its quota sat untouched.
+        if case .desynced(_, let credentialOwner) = liveCredentialOwner(),
+           let index = accounts.firstIndex(where: { $0.id == credentialOwner }) {
+            for i in accounts.indices {
+                accounts[i].isActive = (i == index)
+            }
+            activeAccount = accounts[index]
+            saveAccounts()
+            log.warning("[updateActiveAccount] Claude reports \(email) but the live credential is \(self.accounts[index].email)'s; keeping the credential's owner active")
+            errorMessage = String(localized: "Claude reports \(email), but the stored sign-in is still \(accounts[index].email)'s — another Claude Code session rewrote the identity. Switch accounts once to re-sync.", bundle: L10n.bundle)
+            return
+        }
+
         if let index = accounts.firstIndex(where: { $0.email == email }) {
             for i in accounts.indices {
                 accounts[i].isActive = (i == index)
@@ -1085,7 +1214,9 @@ final class AppState: ObservableObject {
             )
             accounts.append(account)
             activeAccount = account
-            _ = claudeService.captureCurrentCredentials(forAccountId: account.id.uuidString)
+            if claudeService.captureCurrentCredentials(forAccountId: account.id.uuidString) {
+                anchorLiveCredential(to: account.id)
+            }
             saveAccounts()
             log.info("[updateActiveAccount] Auto-created first account, id=\(account.id)")
         } else {

--- a/CCSwitcher/Services/ClaudeService.swift
+++ b/CCSwitcher/Services/ClaudeService.swift
@@ -388,26 +388,31 @@ final class ClaudeService: @unchecked Sendable {
         let shadowedBy: String?
     }
 
-    /// `targetBackup` is resolved by the caller (which can distinguish a
-    /// missing backup from a briefly unreadable store) and handed down so no
-    /// second, ambiguity-collapsing lookup happens here.
+    /// `targetBackup` and `liveCredentialIsSource` are resolved by the caller
+    /// (which can distinguish a missing backup from a briefly unreadable store,
+    /// and holds the credential anchor) and handed down so no second,
+    /// ambiguity-collapsing lookup happens here.
     @discardableResult
-    func switchAccount(from currentAccount: Account, to targetAccount: Account, targetBackup: AccountBackup) async throws -> SwitchOutcome {
+    func switchAccount(from currentAccount: Account, to targetAccount: Account, targetBackup: AccountBackup, liveCredentialIsSource: Bool) async throws -> SwitchOutcome {
         let keychain = KeychainService.shared
 
         log.info("[switchAccount] Switching from \(currentAccount.id) to \(targetAccount.id)")
 
         // 1. Back up current account (token + oauthAccount)
+        //
+        // Gated on the anchor, not on the `oauthAccount` email: that email is
+        // exactly what goes wrong when a Claude Code session rewrites the
+        // identity block, and checking the source against it made the guard
+        // agree with the corruption instead of catching it — backing the
+        // previous account's token up as this one's, which no later switch
+        // undoes.
         log.info("[switchAccount] Step 1: Backing up current account...")
-        if let currentToken = keychain.readClaudeToken(),
-           let currentOAuth = keychain.readOAuthAccount() {
-            let email = (currentOAuth["emailAddress"]?.value as? String) ?? "?"
-            if email == currentAccount.email {
-                let saved = keychain.saveAccountBackup(token: currentToken, oauthAccount: currentOAuth, forAccountId: currentAccount.id.uuidString)
-                log.info("[switchAccount] Step 1: Backup saved: \(saved)")
-            } else {
-                log.warning("[switchAccount] Step 1: oauthAccount email (\(email)) != source (\(currentAccount.email)), skipping backup")
-            }
+        if !liveCredentialIsSource {
+            log.warning("[switchAccount] Step 1: Live credential is not confirmed to be \(currentAccount.email)'s; skipping backup rather than storing it under the wrong account")
+        } else if let currentToken = keychain.readClaudeToken(),
+                  let currentOAuth = keychain.readOAuthAccount() {
+            let saved = keychain.saveAccountBackup(token: currentToken, oauthAccount: currentOAuth, forAccountId: currentAccount.id.uuidString)
+            log.info("[switchAccount] Step 1: Backup saved: \(saved)")
         } else {
             log.warning("[switchAccount] Step 1: Could not read current token or oauthAccount")
         }

--- a/CCSwitcher/Services/CredentialAnchor.swift
+++ b/CCSwitcher/Services/CredentialAnchor.swift
@@ -1,0 +1,152 @@
+import Foundation
+import CryptoKit
+
+private let log = FileLog("Anchor")
+
+/// Who the credential currently sitting in the keychain actually belongs to.
+enum LiveCredentialOwner: Equatable {
+    /// The live credential is known to be this account's.
+    case owned(UUID)
+    /// The live credential belongs to `credential`, but `~/.claude.json` names
+    /// someone else. Usage still attributes to `credential` — that is the token
+    /// every API call is billed against — while the identity block is wrong.
+    case desynced(claimed: UUID?, credential: UUID)
+    /// No credential, or nothing left tying it to a known account.
+    case unknown
+
+    /// The account the live credential belongs to, if that is knowable at all.
+    var credentialAccountId: UUID? {
+        switch self {
+        case .owned(let id): return id
+        case .desynced(_, let id): return id
+        case .unknown: return nil
+        }
+    }
+}
+
+/// Tracks which account the live keychain credential belongs to.
+///
+/// The obvious answer — `~/.claude.json`'s identity block — is not trustworthy:
+/// every running Claude Code session rewrites that block from its own cached
+/// profile, so it can name account B seconds after a switch while the keychain
+/// still holds account A's token. Everything downstream then misfiles A as B:
+/// A's usage reading lands on B's card, and the next switch backs A's token up
+/// as B's stored credential, permanently swapping the two accounts.
+///
+/// So pair the account with a fingerprint of the credential instead, taken at
+/// the one moment the two halves are known to agree: when CCSwitcher itself
+/// wrote them. An unchanged fingerprint proves the credential did not change,
+/// whatever the identity block now claims.
+///
+/// Residual ambiguity, deliberately left: if the credential rotates in the same
+/// window as an identity change, a local check cannot tell an external login
+/// from a desync, and the identity block is believed. Rotation without a
+/// matching identity change is the common case and stays anchored.
+final class CredentialAnchorStore {
+    private struct Anchor: Codable {
+        var accountId: UUID
+        var fingerprint: String
+        /// Set once the identity block has been seen disagreeing with a
+        /// credential that did not change. Sticky on purpose: clearing it on the
+        /// next rotation would let the desync resume misfiling the moment the
+        /// token rolls, which is exactly how the original swap went unnoticed.
+        var isDesynced: Bool
+    }
+
+    private let defaults: UserDefaults
+    private let key = "com.ccswitcher.credentialAnchor"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// Hash rather than the token itself: this lands in UserDefaults, which is
+    /// not a credential store.
+    static func fingerprint(of accessToken: String) -> String {
+        SHA256.hash(data: Data(accessToken.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Record that `accountId` owns the live credential.
+    ///
+    /// Call this only where CCSwitcher established the pairing itself — a
+    /// switch, a login, a re-authentication — never from something the identity
+    /// block merely asserts. This is also the only way out of a desync.
+    func anchor(accountId: UUID, accessToken: String) {
+        let anchor = Anchor(accountId: accountId, fingerprint: Self.fingerprint(of: accessToken), isDesynced: false)
+        save(anchor)
+        log.info("[anchor] Live credential anchored to \(accountId) (\(short(anchor.fingerprint)))")
+    }
+
+    /// Drop the anchor if it points at `accountId` (the account was removed).
+    func forget(accountId: UUID) {
+        guard let stored = load(), stored.accountId == accountId else { return }
+        defaults.removeObject(forKey: key)
+        log.info("[anchor] Dropped anchor for removed account \(accountId)")
+    }
+
+    /// Resolve who the live credential belongs to.
+    ///
+    /// - Parameters:
+    ///   - accessToken: the access token currently in the keychain, if any.
+    ///   - claimedAccountId: the account `~/.claude.json` says is signed in.
+    func resolveOwner(accessToken: String?, claimedAccountId: UUID?) -> LiveCredentialOwner {
+        guard let accessToken else { return .unknown }
+        let fingerprint = Self.fingerprint(of: accessToken)
+
+        guard var stored = load() else {
+            // Nothing anchored yet (first run, or the account was re-added):
+            // the identity block is all there is to go on.
+            guard let claimedAccountId else { return .unknown }
+            save(Anchor(accountId: claimedAccountId, fingerprint: fingerprint, isDesynced: false))
+            return .owned(claimedAccountId)
+        }
+
+        if stored.fingerprint == fingerprint {
+            // The credential has not moved since it was anchored, so it still
+            // belongs to the anchored account no matter what the file says.
+            if stored.isDesynced {
+                return .desynced(claimed: claimedAccountId, credential: stored.accountId)
+            }
+            if let claimedAccountId, claimedAccountId != stored.accountId {
+                stored.isDesynced = true
+                save(stored)
+                log.warning("[anchor] Identity block flipped to \(claimedAccountId) while the credential stayed \(stored.accountId)'s")
+                return .desynced(claimed: claimedAccountId, credential: stored.accountId)
+            }
+            return .owned(stored.accountId)
+        }
+
+        // The credential itself changed.
+        if stored.isDesynced {
+            // It rolled while the identity block was already untrustworthy, so
+            // nothing ties it to an account any more. Only a CCSwitcher-performed
+            // write can re-establish the pairing.
+            stored.fingerprint = fingerprint
+            save(stored)
+            log.warning("[anchor] Credential rotated while desynced; owner is now unknown")
+            return .unknown
+        }
+
+        // Ordinary rotation by a running Claude Code session, or a login done
+        // outside CCSwitcher: the identity block moved with the credential.
+        guard let claimedAccountId else { return .unknown }
+        save(Anchor(accountId: claimedAccountId, fingerprint: fingerprint, isDesynced: false))
+        return .owned(claimedAccountId)
+    }
+
+    // MARK: - Persistence
+
+    private func load() -> Anchor? {
+        guard let data = defaults.data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode(Anchor.self, from: data)
+    }
+
+    private func save(_ anchor: Anchor) {
+        guard let data = try? JSONEncoder().encode(anchor) else { return }
+        defaults.set(data, forKey: key)
+    }
+
+    private func short(_ fingerprint: String) -> String {
+        String(fingerprint.prefix(8))
+    }
+}

--- a/CCSwitcher/de.lproj/Localizable.strings
+++ b/CCSwitcher/de.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 "Token expired. Switch to this account to refresh." = "Token abgelaufen. Zu diesem Konto wechseln zum Aktualisieren.";
 "API Rate Limited. Try again later." = "API-Anfragelimit erreicht. Bitte später erneut versuchen.";
 "Could not fetch usage: %@" = "Nutzung konnte nicht abgerufen werden: %@";
+"Claude reports %@, but the stored sign-in still belongs to %@. Switch accounts once, then add." = "Claude meldet %1$@, aber die gespeicherte Anmeldung gehört weiterhin %2$@. Wechsle einmal das Konto und füge es dann hinzu.";
+"Claude reports %@, but the stored sign-in is still %@'s — another Claude Code session rewrote the identity. Switch accounts once to re-sync." = "Claude meldet %1$@, aber die gespeicherte Anmeldung gehört weiterhin %2$@ – eine andere Claude-Code-Sitzung hat die Identität überschrieben. Wechsle einmal das Konto, um neu zu synchronisieren.";
+"Can't tell which account the current sign-in belongs to. Switch accounts once to re-sync." = "Es lässt sich nicht feststellen, zu welchem Konto die aktuelle Anmeldung gehört. Wechsle einmal das Konto, um neu zu synchronisieren.";
 
 /* Promo */
 "%@ - %@ (Weekdays) & Weekends" = "%1$@ - %2$@ (Wochentags) & Wochenenden";

--- a/CCSwitcher/en.lproj/Localizable.strings
+++ b/CCSwitcher/en.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 "Token expired. Switch to this account to refresh." = "Token expired. Switch to this account to refresh.";
 "API Rate Limited. Try again later." = "API Rate Limited. Try again later.";
 "Could not fetch usage: %@" = "Could not fetch usage: %@";
+"Claude reports %@, but the stored sign-in still belongs to %@. Switch accounts once, then add." = "Claude reports %1$@, but the stored sign-in still belongs to %2$@. Switch accounts once, then add.";
+"Claude reports %@, but the stored sign-in is still %@'s — another Claude Code session rewrote the identity. Switch accounts once to re-sync." = "Claude reports %1$@, but the stored sign-in is still %2$@'s — another Claude Code session rewrote the identity. Switch accounts once to re-sync.";
+"Can't tell which account the current sign-in belongs to. Switch accounts once to re-sync." = "Can't tell which account the current sign-in belongs to. Switch accounts once to re-sync.";
 
 /* Promo */
 "%@ - %@ (Weekdays) & Weekends" = "%@ - %@ (Weekdays) & Weekends";

--- a/CCSwitcher/fr.lproj/Localizable.strings
+++ b/CCSwitcher/fr.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 "Token expired. Switch to this account to refresh." = "Jeton expiré. Basculez vers ce compte pour actualiser.";
 "API Rate Limited. Try again later." = "Limite de l'API atteinte. Réessayez plus tard.";
 "Could not fetch usage: %@" = "Impossible de récupérer l'utilisation : %@";
+"Claude reports %@, but the stored sign-in still belongs to %@. Switch accounts once, then add." = "Claude indique %1$@, mais la connexion enregistrée appartient toujours à %2$@. Changez de compte une fois, puis ajoutez-le.";
+"Claude reports %@, but the stored sign-in is still %@'s — another Claude Code session rewrote the identity. Switch accounts once to re-sync." = "Claude indique %1$@, mais la connexion enregistrée est toujours celle de %2$@ : une autre session Claude Code a réécrit l'identité. Changez de compte une fois pour resynchroniser.";
+"Can't tell which account the current sign-in belongs to. Switch accounts once to re-sync." = "Impossible de déterminer à quel compte appartient la connexion actuelle. Changez de compte une fois pour resynchroniser.";
 
 /* Promo */
 "%@ - %@ (Weekdays) & Weekends" = "%1$@ - %2$@ (Jours ouvrables) & Week-ends";

--- a/CCSwitcher/ja.lproj/Localizable.strings
+++ b/CCSwitcher/ja.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 "Token expired. Switch to this account to refresh." = "トークンが期限切れです。このアカウントに切り替えて更新してください。";
 "API Rate Limited. Try again later." = "API レート制限中。後でもう一度お試しください。";
 "Could not fetch usage: %@" = "使用量を取得できませんでした：%@";
+"Claude reports %@, but the stored sign-in still belongs to %@. Switch accounts once, then add." = "Claude は %1$@ と報告していますが、保存されているサインインは %2$@ のものです。一度アカウントを切り替えてから追加してください。";
+"Claude reports %@, but the stored sign-in is still %@'s — another Claude Code session rewrote the identity. Switch accounts once to re-sync." = "Claude は %1$@ と報告していますが、保存されているサインインは %2$@ のままです。別の Claude Code セッションが識別情報を書き換えました。一度アカウントを切り替えて再同期してください。";
+"Can't tell which account the current sign-in belongs to. Switch accounts once to re-sync." = "現在のサインインがどのアカウントのものか判別できません。一度アカウントを切り替えて再同期してください。";
 
 /* Promo */
 "%@ - %@ (Weekdays) & Weekends" = "%1$@ - %2$@（平日）& 週末";

--- a/CCSwitcher/zh-Hans.lproj/Localizable.strings
+++ b/CCSwitcher/zh-Hans.lproj/Localizable.strings
@@ -137,6 +137,9 @@
 "Token expired. Switch to this account to refresh." = "令牌已过期。切换到此账户以刷新。";
 "API Rate Limited. Try again later." = "API 请求频率受限。请稍后重试。";
 "Could not fetch usage: %@" = "无法获取用量：%@";
+"Claude reports %@, but the stored sign-in still belongs to %@. Switch accounts once, then add." = "Claude 报告的账号是 %1$@，但保存的登录凭据仍属于 %2$@。请先切换一次账号，再添加。";
+"Claude reports %@, but the stored sign-in is still %@'s — another Claude Code session rewrote the identity. Switch accounts once to re-sync." = "Claude 报告的账号是 %1$@，但保存的登录凭据仍是 %2$@ 的 —— 另一个 Claude Code 会话改写了账号标识。请切换一次账号以重新同步。";
+"Can't tell which account the current sign-in belongs to. Switch accounts once to re-sync." = "无法确定当前登录凭据属于哪个账号。请切换一次账号以重新同步。";
 
 /* Promo */
 "%@ - %@ (Weekdays) & Weekends" = "%1$@ - %2$@（工作日）及周末";


### PR DESCRIPTION
Fixes #25.

## 问题

`~/.claude.json` 的身份块不受 CCSwitcher 独占控制——正在运行的 Claude Code 会话会把自己缓存的 `oauthAccount` 写回去。它可以在切换完成 40 秒后就把身份改回上一个账号，而钥匙串里的 token 纹丝不动。有三处把这个身份块当成了"当前凭证属于谁"的答案：

| 位置 | 后果 |
|---|---|
| `fetchAllAccountUsage` / `fetchUsageNow` | A 的额度读数记到 B 的卡片上，因为限流会保留 stale sample，能停留数小时 |
| `switchAccount` Step 1 的备份前检查 | 检查的是 `oauthAccount.emailAddress == currentAccount.email`，而脱钩时 `currentAccount` 本身就是从同一个身份块推出来的——**这道防线在和污染源互相确认**，于是把 A 的 token 存成了 B 的凭证。落盘，后续切换不会修复；之后切到 B 实际烧 A 的额度，界面上完全看不出来 |
| `updateActiveAccount` | 活跃徽章挂在身份块点名的账号上，而不是真正在被计费的那个 |

issue #25 里有完整的日志证据：08:36 和 08:41 两轮之间没有任何 `[switchAccount]` 记录，`readClaudeToken` 长度不变（同一个 token，返回同样的额度），但 `Live oauthAccount` 从 A 变成了 B，于是 `[fetchUsage] B: session=92.0%` —— 那是 A 的数字。

## 改法

把"当前凭证属于谁"从身份块手里拿回来。新增 `CredentialAnchor.swift`：把 account id 和**凭证的 SHA256 指纹**绑在一起，只在 CCSwitcher 自己确立过这个配对的时刻记录——switch / login / re-auth / 就地刷新之后。

- 指纹没变 → 凭证没换过人，身份块说什么都不算数
- 指纹和身份块**同时**变 → 认为是外部登录，采信
- 指纹变了但处于脱钩状态 → 判定为 `unknown`，不猜

**脱钩状态是粘性的**：观察到一次不一致后，不因随后的一次 token 轮换就当作恢复。原来的错误归属正是在轮换那一刻被"洗白"，才藏了几个小时没被发现。

同一个判据替换掉上述三处。另外 `diagnoseTokenHealth()` 每轮多打一行凭证归属——原来的健康检查只校验备份里 `oauthAccount` 的邮箱（`Backup [B]: OK (email=B)`），而被污染的恰恰是 token，元数据是干净的，所以什么都看不出来。

`project.yml` 无需改动（target 按目录收源文件）。文案已补齐 en / zh-Hans / ja / de / fr。

## 需要你拍板的两个决策

我按自己的判断定了，但这属于产品选择，你可能有别的取舍：

1. **脱钩时活跃徽章跟凭证走**，而不是跟身份块走。理由是 API 调用按 token 计费，徽章应该指向真正在掉额度的那个账号。
2. **判定不了时（`unknown`）宁可不显示数字**，在卡片上给一句"无法确定当前登录属于哪个账号，切换一次重新同步"，而不是显示一个可能记错人的百分比。

## 已知的残留盲区

如果 token 轮换和身份块改写恰好落在同一个刷新窗口内，本地无法区分"外部登录"和"脱钩"，此时仍然采信身份块。要彻底消除得靠一个能从 token 反查归属的服务端接口。本次事故不属于这种情况（token 全程未变），但值得记在这里。

另外，本补丁**只防新的污染，修不了已经写坏的凭证槽**——已经中招的用户需要对受影响的账号重新认证一次。

## 验证情况（请注意）

- 按 issue #25 的真实时间线做了回放测试，9 组场景 15 项断言全过（含：脱钩检测、粘性、切换后恢复、正常轮换、外部登录、首次运行、删除账号）
- 全模块 `swiftc -typecheck`（Swift 6 + `-strict-concurrency=targeted`）通过

**但我本机只有 Command Line Tools，没有 Xcode，没能真正构建 .app，也没有装上跑过。** 仓库的 CI 会在 PR 上用 macos-26 构建，我盯着结果，挂了我来修。也请你在合并前实机验一下切换路径。

这个补丁是我用 Claude Code 写的，上面的局限如实写在这里，你按需取舍——只拿思路自己重写也完全没问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
