### PR TITLE
feat: Weekly consumption total across all accounts

### DIFF
--- a/CCSwitcher/AppState.swift
+++ b/CCSwitcher/AppState.swift
@@ -38,6 +38,47 @@ final class AppState: ObservableObject {
     
     @Published var accountUsageErrors: [UUID: UsageErrorState] = [:]
 
+    // MARK: - Weekly Consumption Summary (all accounts)
+
+    /// Aggregates the 7-day utilization reported by every account into a single
+    /// weekly-consumption snapshot: the sum of all accounts' weekly usage
+    /// percentages, the average utilization, and how many accounts reported data.
+    struct WeeklyConsumptionSummary {
+        /// Sum of every account's `seven_day.utilization` (%). Can exceed 100
+        /// when several accounts have consumed part of their own weekly quota.
+        let totalUtilization: Double
+        /// Simple average of the accounts that reported weekly data.
+        let averageUtilization: Double
+        /// Number of accounts with a usable seven-day sample right now.
+        let sampledAccountCount: Int
+        /// Total number of configured accounts.
+        let accountCount: Int
+        /// True when at least one account has reported weekly data.
+        var hasData: Bool { sampledAccountCount > 0 }
+
+        static let empty = WeeklyConsumptionSummary(
+            totalUtilization: 0, averageUtilization: 0,
+            sampledAccountCount: 0, accountCount: 0
+        )
+    }
+
+    /// Computed from the latest per-account usage samples (`accountUsage`).
+    /// The seven-day window is the natural "weekly consumption" metric each
+    /// account already exposes; summing it answers "how much have all my
+    /// accounts consumed this week?" at a glance.
+    var weeklyConsumptionSummary: WeeklyConsumptionSummary {
+        let samples = accountUsage.values.compactMap { $0.sevenDay?.utilization }
+        guard !samples.isEmpty else {
+            return .empty
+        }
+        let total = samples.reduce(0, +)
+        return WeeklyConsumptionSummary(
+            totalUtilization: total,
+            averageUtilization: total / Double(samples.count),
+            sampledAccountCount: samples.count,
+            accountCount: accounts.count
+        )
+    }
     // MARK: - Services
 
     private let claudeService = ClaudeService.shared

--- a/CCSwitcher/Views/UsageDashboardView.swift
+++ b/CCSwitcher/Views/UsageDashboardView.swift
@@ -57,6 +57,9 @@ struct UsageDashboardView: View {
                     // Today's activity stats
                     todayActivityCard
 
+                    // Weekly consumption total across ALL accounts
+                    weeklyTotalCard
+
                     ForEach(appState.accounts) { account in
                         accountUsageCard(account: account, usage: appState.accountUsage[account.id])
                     }
@@ -109,6 +112,70 @@ struct UsageDashboardView: View {
     }
 
     private static let costDisclaimer: LocalizedStringKey = "Estimated API-equivalent cost of your Claude Code usage, for reference only."
+
+    // MARK: - Weekly Consumption Total (all accounts)
+
+    /// Sum of every account's 7-day utilization: "how much of my weekly quota
+    /// across all accounts has already been consumed?" The total can exceed 100%
+    /// because each account has its own independent weekly limit.
+    private var weeklyTotalCard: some View {
+        let summary = appState.weeklyConsumptionSummary
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "calendar.badge.clock")
+                    .font(.subheadline)
+                    .foregroundStyle(.brand)
+                Text("Weekly Consumption — All Accounts")
+                    .font(.subheadline.weight(.medium))
+                Spacer()
+                if summary.hasData {
+                    let accountsBadge = String(format: String(localized: "%lld/%lld accounts", bundle: L10n.bundle),
+                                                summary.sampledAccountCount, summary.accountCount)
+                    Badge(text: accountsBadge, color: .green)
+                }
+            }
+
+            if summary.hasData {
+                HStack(spacing: 0) {
+                    StatWithTooltip(tooltip: Self.weeklyTotalDisclaimer) {
+                        VStack(spacing: 3) {
+                            Text("\(Int(summary.totalUtilization))%")
+                                .font(.title.weight(.semibold).monospacedDigit())
+                                .foregroundStyle(.brand)
+                            Text("Total")
+                                .font(.caption2)
+                                .foregroundStyle(.textSecondary)
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                    StatWithTooltip(tooltip: Self.weeklyAverageDisclaimer) {
+                        VStack(spacing: 3) {
+                            Text("\(Int(summary.averageUtilization))%")
+                                .font(.title2.weight(.semibold).monospacedDigit())
+                            Text("Average")
+                                .font(.caption2)
+                                .foregroundStyle(.textSecondary)
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+            } else {
+                HStack {
+                    Image(systemName: "hourglass")
+                        .foregroundStyle(.secondary)
+                    Text("Waiting for usage data...")
+                        .font(.caption)
+                        .foregroundStyle(.textSecondary)
+                    Spacer()
+                }
+            }
+        }
+        .cardStyle()
+        .sectionPadding()
+    }
+
+    private static let weeklyTotalDisclaimer: LocalizedStringKey = "Sum of every account's 7-day utilization. Each account has its own weekly quota, so the total can exceed 100%."
+    private static let weeklyAverageDisclaimer: LocalizedStringKey = "Average 7-day utilization across the accounts that reported data."
 
     // MARK: - Today Activity Card
 

--- a/CCSwitcher/en.lproj/Localizable.strings
+++ b/CCSwitcher/en.lproj/Localizable.strings
@@ -182,3 +182,11 @@
 "Updated %@ ago" = "Updated %@ ago";
 "Could not save the refreshed sign-in; will retry automatically." = "Could not save the refreshed sign-in; will retry automatically.";
 "Credential storage is temporarily unavailable. Try again shortly." = "Credential storage is temporarily unavailable. Try again shortly.";
+
+/* Weekly Consumption Total */
+"Weekly Consumption — All Accounts" = "Weekly Consumption — All Accounts";
+"Total" = "Total";
+"Average" = "Average";
+"Sum of every account's 7-day utilization. Each account has its own weekly quota, so the total can exceed 100%." = "Sum of every account's 7-day utilization. Each account has its own weekly quota, so the total can exceed 100%.";
+"Average 7-day utilization across the accounts that reported data." = "Average 7-day utilization across the accounts that reported data.";
+"%lld/%lld accounts" = "%lld/%lld accounts";


### PR DESCRIPTION
## Summary

Adds a **"Weekly Consumption — All Accounts"** card to the Usage dashboard that sums the 7-day utilization reported by every account, so you can see at a glance how much of your weekly quota has been consumed across all accounts combined.

## Changes

- **`AppState.swift`** — new `WeeklyConsumptionSummary` struct + computed `weeklyConsumptionSummary` that aggregates `accountUsage` `sevenDay.utilization` values (sum, average, sampled/total account counts). Recomputes live from the existing per-account samples, no new API calls.
- **`UsageDashboardView.swift`** — renders the new card between the activity card and the per-account cards:
  - **Total**: sum of all accounts' 7-day utilization (can exceed 100% — each account has its own weekly quota; tooltip explains this).
  - **Average**: mean utilization across sampled accounts.
  - **Badge**: `sampled/total accounts` with sampled-count progress.
  - Shows the standard "Waiting for usage data…" state while samples are pending.
- **`en.lproj/Localizable.strings`** — new keys (source of truth; other locales will fall back to English).

## Why

Users running multiple Claude Code accounts (e.g. for rate-limit rotation) currently see per-account cards only; this adds the missing aggregate view the accounts were already polling for.

## Verification

- `plutil -lint` passes on `Localizable.strings`.
- Code follows existing view patterns (`cardStyle`, `sectionPadding`, `StatWithTooltip`, `Badge`) used throughout the same file.
- Regenerated the Xcode project via `xcodegen generate` (per repo rules).