### PR TITLE
Add CLI account switching

### DIFF
--- a/CCSwitcher/CCSwitcherApp.swift
+++ b/CCSwitcher/CCSwitcherApp.swift
@@ -34,6 +34,9 @@ struct CCSwitcherApp: App {
         // shows the native toolbar tabs even though the UI is AppKit-based.
         WindowGroup("CCSwitcherKeepalive") {
             HiddenWindowView()
+                .onOpenURL { url in
+                    handleCommandURL(url)
+                }
                 .onAppear {
                     guard !didBootstrap else { return }
                     didBootstrap = true
@@ -70,5 +73,27 @@ struct CCSwitcherApp: App {
 
     private var currentLocale: Locale {
         appLanguage == "auto" ? .autoupdatingCurrent : Locale(identifier: appLanguage)
+    }
+
+    /// Headless command bridge for the local `ccswitch` CLI.
+    /// Example: ccswitcher://switch?email=person%40example.com
+    private func handleCommandURL(_ url: URL) {
+        guard url.scheme?.lowercased() == "ccswitcher",
+              url.host?.lowercased() == "switch",
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let email = components.queryItems?.first(where: { $0.name == "email" })?.value,
+              !email.isEmpty else {
+            return
+        }
+
+        guard let account = appState.accounts.first(where: {
+            $0.email.caseInsensitiveCompare(email) == .orderedSame
+        }) else {
+            return
+        }
+
+        Task { @MainActor in
+            await appState.switchTo(account)
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ CCSwitcher is a lightweight, pure menu bar macOS application designed to help de
 
 - **Non-Interruptive Account Switching**: The native `claude auth logout` clears the current account's credentials, and switching back requires another full OAuth. CCSwitcher keeps a separate backup of each account (keychain token + `~/.claude.json` `oauthAccount` block), atomically swaps both on switch — every added account's credentials stay intact, one-click swap-back, no workflow interruption. (Note: an in-flight `claude` session will pick up the newly-switched credentials on its next API call — this is Claude CLI behavior, not something CCSwitcher controls.)
 - **Multi-Account Management**: Add and switch between different Claude Code accounts with a single click from the macOS menu bar.
+- **CLI Account Switching**: Switch a saved account from the terminal with `ccswitch <email>`. The command delegates the credential swap to the running CCSwitcher app and verifies the result against both Claude Code identity records.
 - **Usage Dashboard**: Real-time monitoring of your Claude API usage limits (5-hour session and weekly) directly in the menu bar dropdown, plus today's API-equivalent cost and activity stats (turns, active minutes, lines written, model breakdown).
 - **Configurable Menu Bar Modules**: Build your own iStats-style menu bar readout. Choose any combination of account name, 5-hour session usage, weekly usage, today's cost, and session/weekly reset countdowns — each rendered as a compact two-line module (label over value, with monochrome progress bars for utilization). Drag to reorder and toggle modules in Settings, with a live preview.
 - **Desktop Widgets**: Native macOS desktop widgets in small, medium, and large sizes showing account usage, costs, and activity stats. Includes a circular ring variant for at-a-glance usage monitoring.
@@ -66,6 +67,24 @@ CCSwitcher is a lightweight, pure menu bar macOS application designed to help de
 <p align="center">
   <video src="https://github.com/user-attachments/assets/ca37eaae-e8d8-4557-995e-bc154442c833" width="864" autoplay loop muted playsinline />
 </p>
+
+## Command-line switching
+
+The release app bundles a small `ccswitch` command. Link it into your PATH once:
+
+```bash
+sudo ln -sf /Applications/CCSwitcher.app/Contents/Resources/ccswitch /usr/local/bin/ccswitch
+```
+
+Then list saved accounts, show the current account, or switch by email:
+
+```bash
+ccswitch list
+ccswitch current
+ccswitch account@example.com
+```
+
+CCSwitcher may already be running or closed. The command launches it in the background when needed, asks the app to perform the same atomic switch used by the menu-bar UI, and exits only after `claude auth status` and `~/.claude.json` both report the requested account.
 
 ## Key Features & Architecture
 

--- a/Tools/ccswitch
+++ b/Tools/ccswitch
@@ -1,0 +1,102 @@
+#!/bin/zsh
+
+set -u
+
+readonly preferences_domain="me.xueshi.ccswitcher"
+accounts_file=""
+
+cleanup() {
+  if [[ -n "$accounts_file" && -f "$accounts_file" ]]; then
+    /bin/unlink "$accounts_file"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+usage() {
+  print -u2 "Usage: ccswitch <email>"
+  print -u2 "       ccswitch current"
+  print -u2 "       ccswitch list"
+}
+
+current_email() {
+  claude auth status --json 2>/dev/null \
+    | plutil -extract email raw -o - - 2>/dev/null
+}
+
+identity_file_email() {
+  plutil -extract oauthAccount.emailAddress raw -o - "$HOME/.claude.json" 2>/dev/null
+}
+
+load_accounts() {
+  [[ -n "$accounts_file" ]] && return 0
+
+  accounts_file=$(mktemp "${TMPDIR:-/tmp}/ccswitch-accounts.XXXXXX") || return 1
+  /usr/bin/defaults export "$preferences_domain" - 2>/dev/null \
+    | xmllint --xpath "string(//key[text()='com.ccswitcher.accounts']/following-sibling::data[1])" - 2>/dev/null \
+    | tr -d '[:space:]' \
+    | base64 -D \
+    | plutil -convert xml1 -o "$accounts_file" - 2>/dev/null
+}
+
+list_accounts() {
+  load_accounts || return 1
+
+  local index=0 email active marker
+  while email=$(plutil -extract "$index.email" raw -o - "$accounts_file" 2>/dev/null); do
+    active=$(plutil -extract "$index.isActive" raw -o - "$accounts_file" 2>/dev/null)
+    [[ "$active" == "true" ]] && marker="*" || marker=" "
+    print -r -- "$marker $email"
+    (( index += 1 ))
+  done
+}
+
+account_exists() {
+  list_accounts | sed 's/^[* ]*//' | grep -Fqx "$1"
+}
+
+case "${1:-}" in
+  current)
+    current_email
+    exit $?
+    ;;
+  list)
+    list_accounts
+    exit $?
+    ;;
+  ""|-h|--help)
+    usage
+    exit 2
+    ;;
+esac
+
+target="$1"
+if ! account_exists "$target"; then
+  print -u2 "Account is not saved in CCSwitcher: $target"
+  exit 3
+fi
+
+if [[ "$(current_email)" == "$target" && "$(identity_file_email)" == "$target" ]]; then
+  print "Already active and verified: $target"
+  exit 0
+fi
+
+encoded="${target//\%/%25}"
+encoded="${encoded//+/%2B}"
+encoded="${encoded//@/%40}"
+if ! open -g "ccswitcher://switch?email=${encoded}"; then
+  print -u2 "Could not open CCSwitcher. Confirm the app is installed."
+  exit 4
+fi
+
+for attempt in {1..45}; do
+  if [[ "$(current_email)" == "$target" && "$(identity_file_email)" == "$target" ]]; then
+    print "Switched and verified: $target"
+    exit 0
+  fi
+  sleep 1
+done
+
+print -u2 "Switch was not verified within 45 seconds."
+print -u2 "claude auth: $(current_email)"
+print -u2 "~/.claude.json: $(identity_file_email)"
+exit 5

--- a/project.yml
+++ b/project.yml
@@ -34,6 +34,8 @@ targets:
     sources:
       - path: CCSwitcher
       - path: Shared
+      - path: Tools/ccswitch
+        buildPhase: resources
     info:
       path: CCSwitcher/Info.plist
       properties:


### PR DESCRIPTION
## Summary

- handle `ccswitcher://switch?email=...` inside the running menu-bar app
- bundle a native macOS `ccswitch` command with `list`, `current`, and `<email>` operations
- delegate the credential mutation to CCSwitcher and wait until both `claude auth status` and `~/.claude.json` confirm the target
- document linking the bundled command into `/usr/local/bin`

## Validation

- generated the project from `project.yml` with XcodeGen
- completed an unsigned Release build successfully
- confirmed the built app contains an executable `Contents/Resources/ccswitch`
- smoke-tested `ccswitch list`, `ccswitch current`, and verification of the already-active account
- ran `zsh -n Tools/ccswitch` and `git diff --check`