### PR TITLE
feat: Show the model-scoped weekly limit (Fable) in the widget, dashboard and menu bar

### DIFF
--- a/CCSwitcher/AppState.swift
+++ b/CCSwitcher/AppState.swift
@@ -1010,6 +1010,7 @@ final class AppState: ObservableObject {
         let widgetAccounts = accounts.map { account in
             let usage = accountUsage[account.id]
             let error = accountUsageErrors[account.id]
+            let modelWeekly = usage?.modelScopedWeekly
             return WidgetAccountData(
                 email: account.displayEmail(obfuscated: !UserDefaults.standard.bool(forKey: "showFullEmail")),
                 displayName: account.effectiveDisplayName(obfuscated: !UserDefaults.standard.bool(forKey: "showFullEmail")),
@@ -1019,6 +1020,9 @@ final class AppState: ObservableObject {
                 sessionResetTime: usage?.fiveHour?.resetTimeString,
                 weeklyUtilization: usage?.sevenDay?.utilization,
                 weeklyResetTime: usage?.sevenDay?.resetTimeString,
+                modelWeeklyLabel: modelWeekly?.modelName,
+                modelWeeklyUtilization: modelWeekly?.window.utilization,
+                modelWeeklyResetTime: modelWeekly?.window.resetTimeString,
                 extraUsageEnabled: usage?.extraUsage?.isEnabled,
                 hasError: error != nil,
                 errorMessage: error?.message

--- a/CCSwitcher/AppState.swift
+++ b/CCSwitcher/AppState.swift
@@ -1038,9 +1038,15 @@ final class AppState: ObservableObject {
             modelUsage: activityStats.modelUsage,
             lastUpdated: Date()
         )
-        data.save()
-        WidgetCenter.shared.reloadAllTimelines()
-        log.debug("[updateWidgetData] Widget data saved and timelines reloaded")
+        // The payload is built on the main actor (it reads @Published state),
+        // but the write itself must not be: the first write into the App Group
+        // container after launch can block in `open()` for tens of seconds,
+        // which used to freeze the menu bar for exactly that long.
+        Task.detached(priority: .utility) {
+            await data.saveInBackground()
+            WidgetCenter.shared.reloadAllTimelines()
+            log.debug("[updateWidgetData] Widget data saved and timelines reloaded")
+        }
     }
 
     // MARK: - Persistence

--- a/CCSwitcher/Models/MenuBarConfig.swift
+++ b/CCSwitcher/Models/MenuBarConfig.swift
@@ -4,6 +4,9 @@ import SwiftUI
 enum LimitBarKind {
     case session
     case weekly
+    /// The weekly limit scoped to a single model (e.g. Fable). Shares the
+    /// 7-day window with `.weekly` but has its own quota and its own color.
+    case modelWeekly
 }
 
 /// Where a limit bar is drawn. Only matters while the user keeps the stock
@@ -30,6 +33,7 @@ final class MenuBarConfig: ObservableObject {
     static let shared = MenuBarConfig()
     static let defaultSessionLimitBarColorHex = "#34C759"
     static let defaultWeeklyLimitBarColorHex = "#0A84FF"
+    static let defaultModelWeeklyLimitBarColorHex = "#AF52DE"
     static let defaultLowRemainingLimitBarColorHex = "#FF3B30"
     static let defaultLowRemainingThreshold = 30.0
 
@@ -55,6 +59,10 @@ final class MenuBarConfig: ObservableObject {
         didSet { persistWeeklyLimitBarColor() }
     }
 
+    @Published var modelWeeklyLimitBarColorHex: String {
+        didSet { persistModelWeeklyLimitBarColor() }
+    }
+
     @Published var lowRemainingLimitBarColorHex: String {
         didSet { persistLowRemainingLimitBarColor() }
     }
@@ -68,6 +76,7 @@ final class MenuBarConfig: ObservableObject {
     private let customizesLimitBarColorsKey = "customizesLimitBarColors"
     private let sessionLimitBarColorKey = "sessionLimitBarColor"
     private let weeklyLimitBarColorKey = "weeklyLimitBarColor"
+    private let modelWeeklyLimitBarColorKey = "modelWeeklyLimitBarColor"
     private let lowRemainingLimitBarColorKey = "lowRemainingLimitBarColor"
     private let lowRemainingWarningThresholdKey = "lowRemainingWarningThreshold"
 
@@ -88,6 +97,8 @@ final class MenuBarConfig: ObservableObject {
             ?? Self.defaultSessionLimitBarColorHex
         self.weeklyLimitBarColorHex = UserDefaults.standard.string(forKey: weeklyLimitBarColorKey)
             ?? Self.defaultWeeklyLimitBarColorHex
+        self.modelWeeklyLimitBarColorHex = UserDefaults.standard.string(forKey: modelWeeklyLimitBarColorKey)
+            ?? Self.defaultModelWeeklyLimitBarColorHex
         self.lowRemainingLimitBarColorHex = UserDefaults.standard.string(forKey: lowRemainingLimitBarColorKey)
             ?? Self.defaultLowRemainingLimitBarColorHex
         if let threshold = UserDefaults.standard.object(forKey: lowRemainingWarningThresholdKey) as? Double {
@@ -117,6 +128,10 @@ final class MenuBarConfig: ObservableObject {
         UserDefaults.standard.set(weeklyLimitBarColorHex, forKey: weeklyLimitBarColorKey)
     }
 
+    private func persistModelWeeklyLimitBarColor() {
+        UserDefaults.standard.set(modelWeeklyLimitBarColorHex, forKey: modelWeeklyLimitBarColorKey)
+    }
+
     private func persistLowRemainingLimitBarColor() {
         UserDefaults.standard.set(lowRemainingLimitBarColorHex, forKey: lowRemainingLimitBarColorKey)
     }
@@ -141,6 +156,10 @@ final class MenuBarConfig: ObservableObject {
 
     var weeklyLimitBarColor: Color {
         Self.color(from: weeklyLimitBarColorHex, fallback: Self.defaultWeeklyLimitBarColorHex)
+    }
+
+    var modelWeeklyLimitBarColor: Color {
+        Self.color(from: modelWeeklyLimitBarColorHex, fallback: Self.defaultModelWeeklyLimitBarColorHex)
     }
 
     var lowRemainingLimitBarColor: Color {
@@ -170,6 +189,8 @@ final class MenuBarConfig: ObservableObject {
             return sessionLimitBarColor
         case .weekly:
             return weeklyLimitBarColor
+        case .modelWeekly:
+            return modelWeeklyLimitBarColor
         }
     }
 

--- a/CCSwitcher/Models/MenuBarModule.swift
+++ b/CCSwitcher/Models/MenuBarModule.swift
@@ -11,37 +11,58 @@ enum MenuBarModule: String, Codable, CaseIterable, Identifiable {
     case sessionBarPlain
     case weeklyBar
     case weeklyBarPlain
+    case modelWeeklyBar
+    case modelWeeklyBarPlain
     case dailyCost
     case sessionReset
     case weeklyReset
+    case modelWeeklyReset
 
     var id: String { rawValue }
 
     /// Short uppercase label shown on the top line of the module.
-    var compactLabel: String {
+    ///
+    /// `modelName` is the display name the usage API gives the model-scoped
+    /// weekly limit ("Fable", …). Only the model-scoped modules read it; they
+    /// fall back to a generic marker on accounts that have no scoped limit, so
+    /// the module still identifies itself next to the plain weekly one.
+    func compactLabel(modelName: String? = nil) -> String {
         switch self {
-        case .account:         return "@"
-        case .sessionBar:      return "5H"
-        case .sessionBarPlain: return "5H"
-        case .weeklyBar:       return "7D"
-        case .weeklyBarPlain:  return "7D"
-        case .dailyCost:       return "TODAY"
-        case .sessionReset:    return "5H↻"
-        case .weeklyReset:     return "7D↻"
+        case .account:              return "@"
+        case .sessionBar:           return "5H"
+        case .sessionBarPlain:      return "5H"
+        case .weeklyBar:            return "7D"
+        case .weeklyBarPlain:       return "7D"
+        case .modelWeeklyBar:       return Self.modelLabel(modelName)
+        case .modelWeeklyBarPlain:  return Self.modelLabel(modelName)
+        case .dailyCost:            return "TODAY"
+        case .sessionReset:         return "5H↻"
+        case .weeklyReset:          return "7D↻"
+        case .modelWeeklyReset:     return Self.modelLabel(modelName) + "↻"
         }
+    }
+
+    /// Uppercased model name, capped so an unexpectedly long tier name can't
+    /// stretch the menu bar. "MODEL" stands in until a sample arrives.
+    private static func modelLabel(_ modelName: String?) -> String {
+        guard let modelName, !modelName.isEmpty else { return "MODEL" }
+        return String(modelName.prefix(6)).uppercased()
     }
 
     /// Human-readable name shown in the Settings reorder list.
     var localizedDisplayName: String {
         switch self {
-        case .account:         return String(localized: "Account name", bundle: L10n.bundle)
-        case .sessionBar:      return String(localized: "Session — usage vs time (5h)", bundle: L10n.bundle)
-        case .sessionBarPlain: return String(localized: "Session usage (5h)", bundle: L10n.bundle)
-        case .weeklyBar:       return String(localized: "Weekly — usage vs time (7d)", bundle: L10n.bundle)
-        case .weeklyBarPlain:  return String(localized: "Weekly usage (7d)", bundle: L10n.bundle)
-        case .dailyCost:       return String(localized: "Daily cost", bundle: L10n.bundle)
-        case .sessionReset:    return String(localized: "Session reset countdown", bundle: L10n.bundle)
-        case .weeklyReset:     return String(localized: "Weekly reset countdown", bundle: L10n.bundle)
+        case .account:              return String(localized: "Account name", bundle: L10n.bundle)
+        case .sessionBar:           return String(localized: "Session — usage vs time (5h)", bundle: L10n.bundle)
+        case .sessionBarPlain:      return String(localized: "Session usage (5h)", bundle: L10n.bundle)
+        case .weeklyBar:            return String(localized: "Weekly — usage vs time (7d)", bundle: L10n.bundle)
+        case .weeklyBarPlain:       return String(localized: "Weekly usage (7d)", bundle: L10n.bundle)
+        case .modelWeeklyBar:       return String(localized: "Model weekly — usage vs time (7d)", bundle: L10n.bundle)
+        case .modelWeeklyBarPlain:  return String(localized: "Model weekly usage (7d)", bundle: L10n.bundle)
+        case .dailyCost:            return String(localized: "Daily cost", bundle: L10n.bundle)
+        case .sessionReset:         return String(localized: "Session reset countdown", bundle: L10n.bundle)
+        case .weeklyReset:          return String(localized: "Weekly reset countdown", bundle: L10n.bundle)
+        case .modelWeeklyReset:     return String(localized: "Model weekly reset countdown", bundle: L10n.bundle)
         }
     }
 }

--- a/CCSwitcher/Models/UsageData.swift
+++ b/CCSwitcher/Models/UsageData.swift
@@ -11,6 +11,7 @@ struct UsageAPIResponse: Codable {
     let sevenDayCowork: UsageWindow?
     let iguanaNecktie: UsageWindow?
     let extraUsage: ExtraUsage?
+    let limits: [RateLimitEntry]?
 
     enum CodingKeys: String, CodingKey {
         case fiveHour = "five_hour"
@@ -21,7 +22,79 @@ struct UsageAPIResponse: Codable {
         case sevenDayCowork = "seven_day_cowork"
         case iguanaNecktie = "iguana_necktie"
         case extraUsage = "extra_usage"
+        case limits
     }
+
+    /// The weekly limit that only applies to one model — "Fable only", and
+    /// whatever replaces it later.
+    ///
+    /// Read out of the self-describing `limits` array, not the fixed
+    /// `seven_day_opus` / `seven_day_sonnet` keys: those now come back `null`
+    /// even on accounts that *do* have a live model-scoped weekly limit, so
+    /// they only survive here as a fallback for older server responses.
+    var modelScopedWeekly: ModelScopedWeekly? {
+        let scoped = (limits ?? []).filter {
+            $0.kind == "weekly_scoped" && !($0.scope?.model?.displayName ?? "").isEmpty
+        }
+        // The server may return more than one scoped window. Surface the one
+        // closest to its cap — that's the one that bites first.
+        if let entry = scoped.max(by: { ($0.percent ?? 0) < ($1.percent ?? 0) }),
+           let name = entry.scope?.model?.displayName {
+            return ModelScopedWeekly(
+                modelName: name,
+                window: UsageWindow(utilization: entry.percent, resetsAt: entry.resetsAt)
+            )
+        }
+        if let opus = sevenDayOpus, opus.utilization != nil {
+            return ModelScopedWeekly(modelName: "Opus", window: opus)
+        }
+        return nil
+    }
+}
+
+/// One entry of the server's `limits` array — the self-describing rate-limit
+/// list that superseded the fixed `seven_day_*` keys.
+struct RateLimitEntry: Codable {
+    /// `"session"`, `"weekly_all"` or `"weekly_scoped"`.
+    let kind: String?
+    /// `"session"` or `"weekly"`.
+    let group: String?
+    let percent: Double?
+    let severity: String?
+    let resetsAt: String?
+    /// Present only on `weekly_scoped` entries.
+    let scope: RateLimitScope?
+    let isActive: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case kind, group, percent, severity, scope
+        case resetsAt = "resets_at"
+        case isActive = "is_active"
+    }
+}
+
+/// What a scoped limit is scoped *to*. Only `model` is decoded; the sibling
+/// `surface` key has no stable shape yet and nothing reads it.
+struct RateLimitScope: Codable {
+    let model: RateLimitScopeModel?
+}
+
+struct RateLimitScopeModel: Codable {
+    /// Frequently `null` — the server identifies the tier by display name.
+    let id: String?
+    let displayName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case displayName = "display_name"
+    }
+}
+
+/// A model-scoped weekly limit, paired with the server's own display name for
+/// the model so the UI never hardcodes a tier.
+struct ModelScopedWeekly {
+    let modelName: String
+    let window: UsageWindow
 }
 
 struct UsageWindow: Codable {

--- a/CCSwitcher/Views/MenuBarModuleView.swift
+++ b/CCSwitcher/Views/MenuBarModuleView.swift
@@ -31,7 +31,7 @@ struct MenuBarModuleView: View {
                 .fixedSize()
         } else {
             VStack(alignment: .center, spacing: 0) {
-                Text(module.compactLabel)
+                Text(module.compactLabel(modelName: modelWeeklyName))
                     .font(.system(size: 8, weight: .semibold))
                     .kerning(0.2)
                     .foregroundStyle(.primary)
@@ -81,6 +81,19 @@ struct MenuBarModuleView: View {
                 fillColor: config.limitBarColor(for: .weekly, utilization: weeklyUtilization, context: .menuBar)
             )
 
+        case .modelWeeklyBar:
+            UtilizationBar(
+                utilization: modelWeeklyUtilization,
+                markerPercent: modelWeeklyTimeElapsed,
+                fillColor: config.limitBarColor(for: .modelWeekly, utilization: modelWeeklyUtilization, context: .menuBar)
+            )
+
+        case .modelWeeklyBarPlain:
+            UtilizationBar(
+                utilization: modelWeeklyUtilization,
+                fillColor: config.limitBarColor(for: .modelWeekly, utilization: modelWeeklyUtilization, context: .menuBar)
+            )
+
         case .dailyCost:
             Text(dailyCostText)
                 .font(.system(size: 10, weight: .medium).monospacedDigit())
@@ -95,6 +108,12 @@ struct MenuBarModuleView: View {
 
         case .weeklyReset:
             Text(weeklyResetText)
+                .font(.system(size: 10, weight: .medium).monospacedDigit())
+                .foregroundStyle(.primary)
+                .fixedSize()
+
+        case .modelWeeklyReset:
+            Text(modelWeeklyResetText)
                 .font(.system(size: 10, weight: .medium).monospacedDigit())
                 .foregroundStyle(.primary)
                 .fixedSize()
@@ -117,6 +136,22 @@ struct MenuBarModuleView: View {
     private var weeklyUtilization: Double? {
         guard let id = appState.activeAccount?.id else { return nil }
         return appState.accountUsage[id]?.sevenDay?.utilization
+    }
+
+    /// The whole model-scoped weekly window for the active account, resolved
+    /// once so label, bar and countdown always describe the same limit.
+    private var modelWeekly: ModelScopedWeekly? {
+        guard let id = appState.activeAccount?.id else { return nil }
+        return appState.accountUsage[id]?.modelScopedWeekly
+    }
+
+    private var modelWeeklyName: String? { modelWeekly?.modelName }
+
+    private var modelWeeklyUtilization: Double? { modelWeekly?.window.utilization }
+
+    private var modelWeeklyTimeElapsed: Double? {
+        _ = tick
+        return modelWeekly?.window.elapsedPercent(windowSeconds: RateLimitWindow.sevenDaySeconds)
     }
 
     private var sessionTimeElapsed: Double? {
@@ -156,6 +191,11 @@ struct MenuBarModuleView: View {
             return "—"
         }
         return s
+    }
+
+    private var modelWeeklyResetText: String {
+        _ = tick
+        return modelWeekly?.window.compactResetString ?? "—"
     }
 }
 

--- a/CCSwitcher/Views/SettingsView.swift
+++ b/CCSwitcher/Views/SettingsView.swift
@@ -124,6 +124,7 @@ struct SettingsView: View {
                 if menuBarConfig.customizesLimitBarColors {
                     ColorPicker("Session bar color", selection: sessionLimitBarColor, supportsOpacity: false)
                     ColorPicker("Weekly bar color", selection: weeklyLimitBarColor, supportsOpacity: false)
+                    ColorPicker("Model weekly bar color", selection: modelWeeklyLimitBarColor, supportsOpacity: false)
                     ColorPicker("Low remaining color", selection: lowRemainingLimitBarColor, supportsOpacity: false)
 
                     VStack(alignment: .leading, spacing: 6) {
@@ -231,6 +232,13 @@ struct SettingsView: View {
         colorBinding(
             keyPath: \.weeklyLimitBarColorHex,
             fallback: MenuBarConfig.defaultWeeklyLimitBarColorHex
+        )
+    }
+
+    private var modelWeeklyLimitBarColor: Binding<Color> {
+        colorBinding(
+            keyPath: \.modelWeeklyLimitBarColorHex,
+            fallback: MenuBarConfig.defaultModelWeeklyLimitBarColorHex
         )
     }
 

--- a/CCSwitcher/Views/UsageDashboardView.swift
+++ b/CCSwitcher/Views/UsageDashboardView.swift
@@ -281,7 +281,7 @@ struct UsageDashboardView: View {
     private func usageBars(_ usage: UsageAPIResponse) -> some View {
         if let session = usage.fiveHour {
             usageRow(
-                label: "Session",
+                label: Text("Session"),
                 resetText: session.resetTimeString,
                 utilization: session.utilization ?? 0,
                 kind: .session
@@ -289,10 +289,20 @@ struct UsageDashboardView: View {
         }
         if let weekly = usage.sevenDay {
             usageRow(
-                label: "Weekly",
+                label: Text("Weekly"),
                 resetText: weekly.resetTimeString,
                 utilization: weekly.utilization ?? 0,
                 kind: .weekly
+            )
+        }
+        // The weekly limit scoped to one model. The server names the model, so
+        // the label is verbatim rather than a localized key.
+        if let scoped = usage.modelScopedWeekly {
+            usageRow(
+                label: Text(verbatim: scoped.modelName),
+                resetText: scoped.window.resetTimeString,
+                utilization: scoped.window.utilization ?? 0,
+                kind: .modelWeekly
             )
         }
     }
@@ -320,14 +330,15 @@ struct UsageDashboardView: View {
 
     // MARK: - Usage Row
 
-    private func usageRow(label: LocalizedStringKey, resetText: String?, utilization: Double, kind: LimitBarKind) -> some View {
+    private func usageRow(label: Text, resetText: String?, utilization: Double, kind: LimitBarKind) -> some View {
         let fillColor = menuBarConfig.limitBarColor(for: kind, utilization: utilization, context: .dashboard)
 
         return VStack(spacing: 5) {
             HStack {
-                Text(label)
+                label
                     .font(.caption)
                     .foregroundStyle(.textSecondary)
+                    .lineLimit(1)
                 Spacer()
                 if let resetText {
                     Text("Resets in \(resetText)")

--- a/CCSwitcher/de.lproj/Localizable.strings
+++ b/CCSwitcher/de.lproj/Localizable.strings
@@ -152,18 +152,22 @@
 "Limit bars" = "Limitbalken";
 "Session bar color" = "Farbe des Sitzungsbalkens";
 "Weekly bar color" = "Farbe des Wochenbalkens";
+"Model weekly bar color" = "Farbe des Modell-Wochenbalkens";
 "Low remaining color" = "Farbe bei geringem Rest";
 "Low remaining threshold" = "Schwelle für geringen Rest";
 "Account name" = "Kontoname";
 "Session usage (5h)" = "Sitzungsnutzung (5h)";
 "Weekly usage (7d)" = "Wochennutzung (7d)";
+"Model weekly usage (7d)" = "Modell-Wochennutzung (7d)";
 "Daily cost" = "Tageskosten";
 "Session reset countdown" = "Sitzungs-Reset Countdown";
 "Weekly reset countdown" = "Wochen-Reset Countdown";
+"Model weekly reset countdown" = "Modell-Wochen-Reset Countdown";
 "Menu Bar" = "Menüleiste";
 "Account display" = "Kontoanzeige";
 "Session — usage vs time (5h)" = "Sitzung — Nutzung vs. Zeit (5 Std.)";
 "Weekly — usage vs time (7d)" = "Woche — Nutzung vs. Zeit (7 Tage)";
+"Model weekly — usage vs time (7d)" = "Modell-Woche — Nutzung vs. Zeit (7 Tage)";
 "The vertical line marks time elapsed in the window; fill past it means you're using faster than the clock." = "Die vertikale Linie zeigt die verstrichene Zeit; Füllung darüber hinaus = schneller als die Uhr verbraucht.";
 "Claude Fable 5 — most powerful model, the new flagship tier" = "Claude Fable 5 — leistungsstärkstes Modell, die neue Flaggschiff-Klasse";
 

--- a/CCSwitcher/en.lproj/Localizable.strings
+++ b/CCSwitcher/en.lproj/Localizable.strings
@@ -156,18 +156,22 @@
 "Limit bars" = "Limit bars";
 "Session bar color" = "Session bar color";
 "Weekly bar color" = "Weekly bar color";
+"Model weekly bar color" = "Model weekly bar color";
 "Low remaining color" = "Low remaining color";
 "Low remaining threshold" = "Low remaining threshold";
 "Account name" = "Account name";
 "Session usage (5h)" = "Session usage (5h)";
 "Weekly usage (7d)" = "Weekly usage (7d)";
+"Model weekly usage (7d)" = "Model weekly usage (7d)";
 "Daily cost" = "Daily cost";
 "Session reset countdown" = "Session reset countdown";
 "Weekly reset countdown" = "Weekly reset countdown";
+"Model weekly reset countdown" = "Model weekly reset countdown";
 "Menu Bar" = "Menu Bar";
 "Account display" = "Account display";
 "Session — usage vs time (5h)" = "Session — usage vs time (5h)";
 "Weekly — usage vs time (7d)" = "Weekly — usage vs time (7d)";
+"Model weekly — usage vs time (7d)" = "Model weekly — usage vs time (7d)";
 "The vertical line marks time elapsed in the window; fill past it means you're using faster than the clock." = "The vertical line marks time elapsed in the window; fill past it means you're using faster than the clock.";
 "Claude Fable 5 — most powerful model, the new flagship tier" = "Claude Fable 5 — most powerful model, the new flagship tier";
 

--- a/CCSwitcher/fr.lproj/Localizable.strings
+++ b/CCSwitcher/fr.lproj/Localizable.strings
@@ -152,18 +152,22 @@
 "Limit bars" = "Barres de limite";
 "Session bar color" = "Couleur de la barre session";
 "Weekly bar color" = "Couleur de la barre hebdo";
+"Model weekly bar color" = "Couleur de la barre hebdo par modèle";
 "Low remaining color" = "Couleur de reste faible";
 "Low remaining threshold" = "Seuil de reste faible";
 "Account name" = "Nom du compte";
 "Session usage (5h)" = "Utilisation de la session (5h)";
 "Weekly usage (7d)" = "Utilisation hebdomadaire (7j)";
+"Model weekly usage (7d)" = "Utilisation hebdomadaire par modèle (7j)";
 "Daily cost" = "Coût quotidien";
 "Session reset countdown" = "Compte à rebours réinitialisation session";
 "Weekly reset countdown" = "Compte à rebours réinitialisation semaine";
+"Model weekly reset countdown" = "Compte à rebours réinitialisation hebdo par modèle";
 "Menu Bar" = "Barre de menus";
 "Account display" = "Affichage du compte";
 "Session — usage vs time (5h)" = "Session — usage vs temps (5 h)";
 "Weekly — usage vs time (7d)" = "Hebdomadaire — usage vs temps (7 j)";
+"Model weekly — usage vs time (7d)" = "Hebdomadaire par modèle — usage vs temps (7 j)";
 "The vertical line marks time elapsed in the window; fill past it means you're using faster than the clock." = "La ligne verticale indique le temps écoulé ; remplissage au-delà = consommation plus rapide que l'horloge.";
 "Claude Fable 5 — most powerful model, the new flagship tier" = "Claude Fable 5 — le modèle le plus puissant, le nouveau niveau phare";
 

--- a/CCSwitcher/ja.lproj/Localizable.strings
+++ b/CCSwitcher/ja.lproj/Localizable.strings
@@ -152,18 +152,22 @@
 "Limit bars" = "制限バー";
 "Session bar color" = "セッションバーの色";
 "Weekly bar color" = "週間バーの色";
+"Model weekly bar color" = "モデル別週間バーの色";
 "Low remaining color" = "残量低下時の色";
 "Low remaining threshold" = "残量低下しきい値";
 "Account name" = "アカウント名";
 "Session usage (5h)" = "セッション使用量（5時間）";
 "Weekly usage (7d)" = "週間使用量（7日）";
+"Model weekly usage (7d)" = "モデル別週間使用量（7日）";
 "Daily cost" = "本日の料金";
 "Session reset countdown" = "セッション リセット カウントダウン";
 "Weekly reset countdown" = "週間 リセット カウントダウン";
+"Model weekly reset countdown" = "モデル別週間 リセット カウントダウン";
 "Menu Bar" = "メニューバー";
 "Account display" = "アカウント表示";
 "Session — usage vs time (5h)" = "セッション — 使用量 vs 時間（5時間）";
 "Weekly — usage vs time (7d)" = "週間 — 使用量 vs 時間（7日）";
+"Model weekly — usage vs time (7d)" = "モデル別週間 — 使用量 vs 時間（7日）";
 "The vertical line marks time elapsed in the window; fill past it means you're using faster than the clock." = "縦線 = 経過時間（その時間枠の進捗）。塗りつぶしがこれを超える = 時間より速く消費しています。";
 "Claude Fable 5 — most powerful model, the new flagship tier" = "Claude Fable 5 — 最も強力なモデル、新しいフラッグシップ層";
 

--- a/CCSwitcher/zh-Hans.lproj/Localizable.strings
+++ b/CCSwitcher/zh-Hans.lproj/Localizable.strings
@@ -152,18 +152,22 @@
 "Limit bars" = "额度条";
 "Session bar color" = "会话条颜色";
 "Weekly bar color" = "每周条颜色";
+"Model weekly bar color" = "模型每周条颜色";
 "Low remaining color" = "低剩余额度颜色";
 "Low remaining threshold" = "低剩余额度阈值";
 "Account name" = "账户名称";
 "Session usage (5h)" = "会话用量（5小时）";
 "Weekly usage (7d)" = "每周用量（7天）";
+"Model weekly usage (7d)" = "模型每周用量（7天）";
 "Daily cost" = "今日花费";
 "Session reset countdown" = "会话重置倒计时";
 "Weekly reset countdown" = "每周重置倒计时";
+"Model weekly reset countdown" = "模型每周重置倒计时";
 "Menu Bar" = "菜单栏";
 "Account display" = "账户显示";
 "Session — usage vs time (5h)" = "会话 — 用量 vs 时间（5小时）";
 "Weekly — usage vs time (7d)" = "每周 — 用量 vs 时间（7天）";
+"Model weekly — usage vs time (7d)" = "模型每周 — 用量 vs 时间（7天）";
 "The vertical line marks time elapsed in the window; fill past it means you're using faster than the clock." = "竖线 = 时间进度（该时段已过去多少）；填充超过它 = 你用得比时间快。";
 "Claude Fable 5 — most powerful model, the new flagship tier" = "Claude Fable 5 — 最强大的模型，全新旗舰层级";
 

--- a/CCSwitcherWidget/CCSwitcherWidget.swift
+++ b/CCSwitcherWidget/CCSwitcherWidget.swift
@@ -24,6 +24,9 @@ struct CCSwitcherEntry: TimelineEntry {
                     sessionResetTime: "2 hr 15 min",
                     weeklyUtilization: 28,
                     weeklyResetTime: "in 3 days",
+                    modelWeeklyLabel: "Fable",
+                    modelWeeklyUtilization: 34,
+                    modelWeeklyResetTime: "in 3 days",
                     extraUsageEnabled: true,
                     hasError: false,
                     errorMessage: nil
@@ -106,6 +109,23 @@ struct CCSwitcherWidgetEntryView: View {
 
 // MARK: - Small Widget
 
+/// Vertical density for the small widget.
+///
+/// A model-scoped weekly bar (e.g. "Fable") adds a third row to a layout that
+/// was already close to the 155pt edge, so the whole layout is offered at
+/// several densities and `ViewThatFits` picks the roomiest one that still fits.
+/// Accounts without a scoped limit keep the original `.roomy` look.
+private struct BarDensity {
+    let stackSpacing: CGFloat
+    let barSpacing: CGFloat
+    let barHeight: CGFloat
+    let costFont: Font
+
+    static let roomy = BarDensity(stackSpacing: 6, barSpacing: 3, barHeight: 5, costFont: .title3)
+    static let tight = BarDensity(stackSpacing: 4, barSpacing: 2, barHeight: 4, costFont: .callout)
+    static let tightest = BarDensity(stackSpacing: 2, barSpacing: 2, barHeight: 4, costFont: .subheadline)
+}
+
 private struct SmallWidgetView: View {
     let data: WidgetData
 
@@ -114,32 +134,16 @@ private struct SmallWidgetView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            // Header — icon + account + badge
-            HStack(spacing: 5) {
-                Image(systemName: "brain.head.profile")
-                    .font(.caption)
-                    .foregroundStyle(brandColor)
-                    .widgetAccentable()
-                if let account = activeAccount {
-                    Text(account.displayName)
-                        .font(.caption.weight(.semibold))
-                        .lineLimit(1)
-                    Spacer()
-                    if let sub = account.subscriptionType {
-                        Text(sub)
-                            .font(.caption2.weight(.medium))
-                            .foregroundStyle(brandColor)
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 1)
-                            .background(brandColor.opacity(0.15), in: Capsule())
-                    }
-                } else {
-                    Text("CCSwitcher")
-                        .font(.caption.weight(.semibold))
-                    Spacer()
-                }
-            }
+        ViewThatFits(in: .vertical) {
+            content(.roomy)
+            content(.tight)
+            content(.tightest)
+        }
+    }
+
+    private func content(_ density: BarDensity) -> some View {
+        VStack(alignment: .leading, spacing: density.stackSpacing) {
+            header
 
             if let account = activeAccount {
                 Spacer(minLength: 2)
@@ -163,8 +167,11 @@ private struct SmallWidgetView: View {
                         }
                     }
                 } else {
-                    compactUsageBar(label: "Session", utilization: account.sessionUtilization)
-                    compactUsageBar(label: "Weekly", utilization: account.weeklyUtilization)
+                    compactUsageBar(label: Text("Session"), utilization: account.sessionUtilization, density: density)
+                    compactUsageBar(label: Text("Weekly"), utilization: account.weeklyUtilization, density: density)
+                    if let model = account.modelWeeklyLabel {
+                        compactUsageBar(label: Text(verbatim: model), utilization: account.modelWeeklyUtilization, density: density)
+                    }
                 }
 
                 Spacer(minLength: 2)
@@ -172,7 +179,7 @@ private struct SmallWidgetView: View {
                 // Today's cost
                 HStack {
                     Text(formatCost(data.todayCost))
-                        .font(.title3.weight(.semibold).monospacedDigit())
+                        .font(density.costFont.weight(.semibold).monospacedDigit())
                         .foregroundStyle(.green)
                     Text("today")
                         .font(.caption)
@@ -189,13 +196,42 @@ private struct SmallWidgetView: View {
         }
     }
 
-    private func compactUsageBar(label: LocalizedStringKey, utilization: Double?) -> some View {
+    // Header — icon + account + badge
+    private var header: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "brain.head.profile")
+                .font(.caption)
+                .foregroundStyle(brandColor)
+                .widgetAccentable()
+            if let account = activeAccount {
+                Text(account.displayName)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                Spacer()
+                if let sub = account.subscriptionType {
+                    Text(sub)
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(brandColor)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(brandColor.opacity(0.15), in: Capsule())
+                }
+            } else {
+                Text("CCSwitcher")
+                    .font(.caption.weight(.semibold))
+                Spacer()
+            }
+        }
+    }
+
+    private func compactUsageBar(label: Text, utilization: Double?, density: BarDensity) -> some View {
         let pct = utilization ?? 0
-        return VStack(spacing: 3) {
+        return VStack(spacing: density.barSpacing) {
             HStack {
-                Text(label)
+                label
                     .font(.caption2)
                     .foregroundStyle(.secondary)
+                    .lineLimit(1)
                 Spacer()
                 Text("\(Int(pct))%")
                     .font(.caption2.weight(.medium).monospacedDigit())
@@ -205,13 +241,13 @@ private struct SmallWidgetView: View {
                 ZStack(alignment: .leading) {
                     RoundedRectangle(cornerRadius: 2.5)
                         .fill(.quaternary)
-                        .frame(height: 5)
+                        .frame(height: density.barHeight)
                     RoundedRectangle(cornerRadius: 2.5)
                         .fill(colorForUtilization(pct))
-                        .frame(width: max(0, geo.size.width * min(pct / 100.0, 1.0)), height: 5)
+                        .frame(width: max(0, geo.size.width * min(pct / 100.0, 1.0)), height: density.barHeight)
                 }
             }
-            .frame(height: 5)
+            .frame(height: density.barHeight)
         }
     }
 }
@@ -279,9 +315,14 @@ private struct MediumWidgetView: View {
                             Spacer(minLength: 0)
                         } else {
                             Spacer(minLength: 0)
-                            usageBar(label: "Session", utilization: account.sessionUtilization, resetTime: account.sessionResetTime)
+                            usageBar(label: Text("Session"), utilization: account.sessionUtilization, resetTime: account.sessionResetTime)
                             Spacer(minLength: 4)
-                            usageBar(label: "Weekly", utilization: account.weeklyUtilization, resetTime: account.weeklyResetTime)
+                            usageBar(label: Text("Weekly"), utilization: account.weeklyUtilization, resetTime: account.weeklyResetTime)
+
+                            if let model = account.modelWeeklyLabel {
+                                Spacer(minLength: 4)
+                                usageBar(label: Text(verbatim: model), utilization: account.modelWeeklyUtilization, resetTime: account.modelWeeklyResetTime)
+                            }
 
                             if let extra = account.extraUsageEnabled {
                                 Spacer(minLength: 4)
@@ -325,18 +366,24 @@ private struct MediumWidgetView: View {
         }
     }
 
-    private func usageBar(label: LocalizedStringKey, utilization: Double?, resetTime: String?) -> some View {
+    private func usageBar(label: Text, utilization: Double?, resetTime: String?) -> some View {
         let pct = utilization ?? 0
         return VStack(spacing: 3) {
             HStack {
-                Text(label)
+                label
                     .font(.caption2)
                     .foregroundStyle(.secondary)
+                    .lineLimit(1)
                 Spacer()
                 if let reset = resetTime {
+                    // Absolute reset times ("Wed 8:00 PM") wrap to two lines
+                    // otherwise, and with three bars stacked there is no room
+                    // for that.
                     Text(reset)
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
                 }
                 Text("\(Int(pct))%")
                     .font(.caption2.weight(.medium).monospacedDigit())
@@ -375,11 +422,38 @@ private struct MediumWidgetView: View {
 
 // MARK: - Large Widget
 
+/// Vertical density for the large widget.
+///
+/// A model-scoped weekly bar (e.g. "Fable") adds a row to *every* account card,
+/// which the stock spacing cannot absorb past a single account. Rather than
+/// clipping the last card, the whole layout is offered at several densities and
+/// `ViewThatFits` picks the roomiest that still fits — which also stops the
+/// three-account case from spilling over the way it used to.
+private struct LargeDensity {
+    let bodySpacing: CGFloat
+    let statsSpacing: CGFloat
+    let statsPadding: CGFloat
+    let cardSpacing: CGFloat
+    let cardPadding: CGFloat
+
+    static let roomy = LargeDensity(bodySpacing: 8, statsSpacing: 6, statsPadding: 10, cardSpacing: 10, cardPadding: 12)
+    static let tight = LargeDensity(bodySpacing: 6, statsSpacing: 5, statsPadding: 7, cardSpacing: 7, cardPadding: 9)
+    static let tightest = LargeDensity(bodySpacing: 4, statsSpacing: 3, statsPadding: 4, cardSpacing: 4, cardPadding: 5)
+}
+
 private struct LargeWidgetView: View {
     let data: WidgetData
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        ViewThatFits(in: .vertical) {
+            content(.roomy)
+            content(.tight)
+            content(.tightest)
+        }
+    }
+
+    private func content(_ density: LargeDensity) -> some View {
+        VStack(alignment: .leading, spacing: density.bodySpacing) {
             // Header
             HStack(spacing: 5) {
                 Image(systemName: "brain.head.profile")
@@ -395,7 +469,7 @@ private struct LargeWidgetView: View {
             }
 
             // Today's activity + model usage
-            VStack(spacing: 6) {
+            VStack(spacing: density.statsSpacing) {
                 HStack(spacing: 0) {
                     activityStat(icon: "bubble.left.and.bubble.right", value: "\(data.conversationTurns)", label: "Turns")
                     activityStat(icon: "clock", value: data.activeCodingTime, label: "Active")
@@ -417,12 +491,12 @@ private struct LargeWidgetView: View {
                     }
                 }
             }
-            .padding(.vertical, 10)
+            .padding(.vertical, density.statsPadding)
             .background(brandColor.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
 
             // Per-account cards — expand to fill remaining space
             ForEach(Array(data.accounts.enumerated()), id: \.offset) { _, account in
-                accountCard(account)
+                accountCard(account, spacing: density.cardSpacing, padding: density.cardPadding)
                     .frame(maxHeight: .infinity)
             }
         }
@@ -462,8 +536,8 @@ private struct LargeWidgetView: View {
         .frame(maxWidth: .infinity)
     }
 
-    private func accountCard(_ account: WidgetAccountData) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
+    private func accountCard(_ account: WidgetAccountData, spacing: CGFloat, padding: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: spacing) {
             // Account header
             HStack(spacing: 6) {
                 Image(systemName: "brain.head.profile")
@@ -509,12 +583,15 @@ private struct LargeWidgetView: View {
                     }
                 }
             } else {
-                accountUsageBar(label: "Session", utilization: account.sessionUtilization, resetTime: account.sessionResetTime)
-                accountUsageBar(label: "Weekly", utilization: account.weeklyUtilization, resetTime: account.weeklyResetTime)
+                accountUsageBar(label: Text("Session"), utilization: account.sessionUtilization, resetTime: account.sessionResetTime)
+                accountUsageBar(label: Text("Weekly"), utilization: account.weeklyUtilization, resetTime: account.weeklyResetTime)
+                if let model = account.modelWeeklyLabel {
+                    accountUsageBar(label: Text(verbatim: model), utilization: account.modelWeeklyUtilization, resetTime: account.modelWeeklyResetTime)
+                }
             }
         }
         .padding(.horizontal, 12)
-        .padding(.vertical, 12)
+        .padding(.vertical, padding)
         .background(
             RoundedRectangle(cornerRadius: 8)
                 .fill(account.isActive ? brandColor.opacity(0.22) : Color.white.opacity(0.04))
@@ -522,12 +599,13 @@ private struct LargeWidgetView: View {
         )
     }
 
-    private func accountUsageBar(label: LocalizedStringKey, utilization: Double?, resetTime: String?) -> some View {
+    private func accountUsageBar(label: Text, utilization: Double?, resetTime: String?) -> some View {
         let pct = utilization ?? 0
         return HStack(spacing: 6) {
-            Text(label)
+            label
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+                .lineLimit(1)
                 .frame(width: 48, alignment: .leading)
             GeometryReader { geo in
                 ZStack(alignment: .leading) {
@@ -582,19 +660,34 @@ private struct CircleWidgetView: View {
             Spacer(minLength: 0)
 
             if let account = activeAccount, !account.hasError {
-                HStack(spacing: 12) {
+                // A third ring has to share the same 155pt tile, so both the
+                // gap and the stroke get thinner rather than the rings.
+                let model = account.modelWeeklyLabel
+                let lineWidth: CGFloat = model == nil ? 6 : 5
+                HStack(spacing: model == nil ? 12 : 8) {
                     ringStat(
-                        label: "Session",
+                        label: Text("Session"),
                         resetTime: account.sessionResetTime,
                         utilization: account.sessionUtilization,
-                        accent: colorForUtilization(account.sessionUtilization ?? 0)
+                        accent: colorForUtilization(account.sessionUtilization ?? 0),
+                        lineWidth: lineWidth
                     )
                     ringStat(
-                        label: "Weekly",
+                        label: Text("Weekly"),
                         resetTime: account.weeklyResetTime,
                         utilization: account.weeklyUtilization,
-                        accent: colorForUtilization(account.weeklyUtilization ?? 0)
+                        accent: colorForUtilization(account.weeklyUtilization ?? 0),
+                        lineWidth: lineWidth
                     )
+                    if let model {
+                        ringStat(
+                            label: Text(verbatim: model),
+                            resetTime: account.modelWeeklyResetTime,
+                            utilization: account.modelWeeklyUtilization,
+                            accent: colorForUtilization(account.modelWeeklyUtilization ?? 0),
+                            lineWidth: lineWidth
+                        )
+                    }
                 }
                 .frame(maxWidth: .infinity)
             } else if let account = activeAccount, account.hasError {
@@ -626,29 +719,36 @@ private struct CircleWidgetView: View {
         }
     }
 
-    private func ringStat(label: LocalizedStringKey, resetTime: String?, utilization: Double?, accent: Color) -> some View {
+    private func ringStat(label: Text, resetTime: String?, utilization: Double?, accent: Color, lineWidth: CGFloat) -> some View {
         let pct = utilization ?? 0
         return VStack(spacing: 4) {
             ZStack {
                 Circle()
-                    .stroke(.quaternary, lineWidth: 6)
+                    .stroke(.quaternary, lineWidth: lineWidth)
                 Circle()
                     .trim(from: 0, to: min(pct / 100.0, 1.0))
-                    .stroke(accent, style: StrokeStyle(lineWidth: 6, lineCap: .round))
+                    .stroke(accent, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
                     .rotationEffect(.degrees(-90))
                 Text("\(Int(pct))%")
                     .font(.caption.weight(.semibold).monospacedDigit())
+                    .minimumScaleFactor(0.7)
+                    .lineLimit(1)
             }
             .aspectRatio(1, contentMode: .fit)
 
-            Text(label)
+            label
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
             if let reset = resetTime {
+                // Three rings leave ~35pt per column; shrink the countdown
+                // rather than ellipsizing it down to "Wed…".
                 Text(reset)
                     .font(.system(size: 9))
                     .foregroundStyle(.tertiary)
                     .lineLimit(1)
+                    .minimumScaleFactor(0.65)
             }
         }
         .frame(maxWidth: .infinity)

--- a/Shared/WidgetData.swift
+++ b/Shared/WidgetData.swift
@@ -13,6 +13,12 @@ struct WidgetAccountData: Codable {
     let sessionResetTime: String?
     let weeklyUtilization: Double?
     let weeklyResetTime: String?
+    /// Display name of the model the scoped weekly limit applies to (e.g.
+    /// "Fable"), or nil when the account has no model-scoped weekly limit.
+    /// Optional — a payload written by an older build simply decodes to nil.
+    let modelWeeklyLabel: String?
+    let modelWeeklyUtilization: Double?
+    let modelWeeklyResetTime: String?
     let extraUsageEnabled: Bool?
     let hasError: Bool
     let errorMessage: String?

--- a/Shared/WidgetData.swift
+++ b/Shared/WidgetData.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// The main app (non-sandboxed) writes a JSON file into the widget extension's container directory.
 /// The widget (sandboxed) reads from its own Application Support, which maps to the same path.
-struct WidgetAccountData: Codable {
+struct WidgetAccountData: Codable, Sendable {
     let email: String          // pre-obfuscated
     let displayName: String    // pre-obfuscated
     let subscriptionType: String?
@@ -24,7 +24,7 @@ struct WidgetAccountData: Codable {
     let errorMessage: String?
 }
 
-struct WidgetData: Codable {
+struct WidgetData: Codable, Sendable {
     let accounts: [WidgetAccountData]
     let todayCost: Double
     let conversationTurns: Int
@@ -53,11 +53,46 @@ struct WidgetData: Codable {
     }
 
     /// Save to the shared App Group container.
+    ///
+    /// Blocking. The FIRST write after launch can sit in `open()` for tens of
+    /// seconds while `containermanagerd` materializes the group container
+    /// (later writes are sub-millisecond), so never call this from the main
+    /// actor — use `saveInBackground()`.
     func save() {
         guard let containerURL = Self.sharedContainerURL else { return }
         let fileURL = containerURL.appendingPathComponent(Self.fileName)
         if let data = try? JSONEncoder().encode(self) {
             try? data.write(to: fileURL, options: .atomic)
         }
+    }
+}
+
+/// Serializes widget writes off the caller's actor.
+///
+/// `WidgetData.save()` ends in an atomic write inside the App Group container.
+/// That write is normally instant, but the first one after a cold launch has
+/// been measured blocking in `open()` for 11–62s while the container is
+/// materialized. Running it on the `@MainActor` froze the menu bar for exactly
+/// that long. The actor also stops two overlapping refreshes from interleaving
+/// writes.
+private actor WidgetDataWriter {
+    static let shared = WidgetDataWriter()
+
+    private var lastWritten: Date = .distantPast
+
+    func write(_ data: WidgetData) {
+        // A cold write can stay in flight for a minute, long enough for a
+        // later refresh to queue behind it. Drop the stale snapshot rather
+        // than letting it land on top of newer numbers.
+        guard data.lastUpdated >= lastWritten else { return }
+        lastWritten = data.lastUpdated
+        data.save()
+    }
+}
+
+extension WidgetData {
+    /// Persist without blocking the caller's actor. See `WidgetDataWriter`.
+    func saveInBackground() async {
+        await WidgetDataWriter.shared.write(self)
     }
 }


### PR DESCRIPTION
## The gap

The usage API reports a third rate limit that nothing in the app surfaced: the weekly quota scoped to a single model. Today CCSwitcher shows only Session and Weekly.

It arrives as a `weekly_scoped` entry in the newer, self-describing `limits` array:

```json
{ "kind": "weekly_scoped", "group": "weekly", "percent": 34,
  "resets_at": "...", "is_active": true,
  "scope": { "model": { "id": null, "display_name": "Fable" } } }
```

The fixed `seven_day_opus` key this repo already declared (but never rendered) is now **always `null`** on live accounts, so it survives here only as a fallback for older server responses. The label comes from the server, so no tier name is hardcoded — it will follow whatever model gets scoped next.

## What's shown

Each surface renders the extra limit only when the account actually has one; accounts without a scoped limit are visually unchanged.

- **Widget** — a third bar/ring in the small, medium, large and rings layouts.
- **Usage dashboard** — a third row under Session/Weekly.
- **Menu bar** — three new modules: bar with pace tick, plain bar, and reset countdown. **Off by default**, so no existing menu bar changes on upgrade. They label themselves from live data (`FABLE` / `FABLE↻`), falling back to `MODEL` before the first sample and capped at 6 characters so an unexpected tier name can't stretch the bar.

`LimitBarKind` gains a `.modelWeekly` case with its own picker in Settings (default system purple `#AF52DE`). Stock colors stay untouched while the customize toggle is off, and the low-remaining threshold still overrides it exactly like the other bars. New strings are localized in all five languages.

## Layout

A third row doesn't fit the widget at the stock spacing, so the small and large layouts now offer themselves at several densities via `ViewThatFits` and SwiftUI picks the roomiest that fits. Accounts with no scoped limit render pixel-identically to before.

Side effect: this **fixes a pre-existing bug** — the large widget already clipped its header and bottom card at three accounts with only two bars. It now fits three accounts x three bars.

Two other pre-existing issues that a third row made visible are also tightened: the medium widget's reset text wrapped to two lines (`Wed 8:00 / PM`), and the rings widget's countdown ellipsized to `Wed…`.

## Verification

- Debug and Release builds clean, no new warnings.
- Decoding tested against a live `/api/oauth/usage` payload plus legacy-shape (`seven_day_opus` populated, no `limits` array), no-scoped-limit, null `display_name`, and two-scoped-window responses.
- Every widget family rendered headlessly at exact macOS pixel sizes (155x155, 329x155, 329x345) rather than eyeballing the math, at one, two and three accounts, with and without a scoped limit, plus the error state.
- Menu bar strip and Usage dashboard snapshotted from the real view code with stubbed state: stock and custom palettes, light and dark, and the no-data fallback.

No version bump or release-notes changes are included.

---

## Second commit: keep the widget-data write off the main actor

Unrelated to the feature, but found while testing it and worth fixing here since it lives in the same file.

`AppState.updateWidgetData()` ran `WidgetData.save()` synchronously on the `@MainActor`. That write is normally sub-millisecond, but the **first one after a cold launch** blocks inside `open()` while `containermanagerd` materializes the App Group container. A `sample` of the stalled process put **42.6% of all main-thread samples** in:

```
WidgetData.save()  ->  Data.write(to:options:)  ->  open()
```

Across 433 writes in the log the median is 0.01s, and the only three above 1s were the first write after each of three launches: **11.50s, 35.36s, 61.95s**. The menu bar was frozen for exactly that long.

The payload is still built on the main actor (it reads `@Published` state), but the write now goes through a `WidgetDataWriter` actor. A `lastUpdated` guard drops a stale snapshot rather than letting a slow in-flight write land on top of newer numbers — a race the now-concurrent writes made possible.

The same measurement after the change reports **0%** of main-thread samples in the write, with widget data still landing correctly.

Note on reproducing: the multi-second `open()` was observed on a locally **ad-hoc-signed** build, where the team-prefixed App Group can't be validated against a signature with no team identifier. A properly signed build resolves the container immediately (0.00s in the logs). The main-actor write is a latent bug either way — any slow or contended write freezes the UI — which is why it is fixed rather than dismissed as a signing artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
