### PR TITLE
fix: refuse an emptied credential backup and roll back a failed switch

### DIFF
--- a/CCSwitcher/AppState.swift
+++ b/CCSwitcher/AppState.swift
@@ -443,6 +443,16 @@ final class AppState: ObservableObject {
         let targetBackup: AccountBackup
         switch keychain.lookupAccountBackup(forAccountId: account.id.uuidString) {
         case .found(let backup):
+            // "A backup exists" and "a backup that can log anyone in exists"
+            // are different facts. A capture taken while the CLI held no live
+            // login stores an intact envelope around two empty secrets, and it
+            // reads as present everywhere else in the app. Writing it would
+            // trade a working session for a dead one.
+            guard backup.hasUsableCredentials else {
+                log.error("[switchTo] ABORT: backup for target account carries no OAuth secret")
+                errorMessage = String(localized: "The stored credentials for \(account.email) are empty. Use re-authenticate to sign in again.", bundle: L10n.bundle)
+                return
+            }
             targetBackup = backup
         case .missing:
             log.error("[switchTo] ABORT: no backup for target account")
@@ -488,10 +498,14 @@ final class AppState: ObservableObject {
     // MARK: - Auto-switch
 
     /// Whether an account can be switched to right now: it must have a stored
-    /// backup token and not be flagged expired (an expired backup would fail the
+    /// backup token that still carries an OAuth secret, and not be flagged
+    /// expired (an emptied or expired backup would fail the
     /// switch verification, or silently swap in a dead session).
     private func isSwitchable(_ account: Account) -> Bool {
-        guard keychain.getAccountBackup(forAccountId: account.id.uuidString) != nil else { return false }
+        guard let backup = keychain.getAccountBackup(forAccountId: account.id.uuidString) else { return false }
+        // An emptied backup would fail the switch the same way an expired one
+        // does, and auto-switch has no user in front of it to read the error.
+        guard backup.hasUsableCredentials else { return false }
         if let error = accountUsageErrors[account.id], error.isExpired { return false }
         return true
     }

--- a/CCSwitcher/AppState.swift
+++ b/CCSwitcher/AppState.swift
@@ -1009,7 +1009,14 @@ final class AppState: ObservableObject {
         for account in accounts {
             if let backup = keychain.getAccountBackup(forAccountId: account.id.uuidString) {
                 let backupEmail = (backup.oauthAccount["emailAddress"]?.value as? String) ?? "?"
-                log.info("[diagnose] Backup [\(account.email)]: OK (email=\(backupEmail))")
+                // The email lives in `oauthAccount`, and an emptied backup keeps
+                // that block intact, so checking it alone reports a backup that
+                // cannot log anyone in as healthy.
+                if backup.hasUsableCredentials {
+                    log.info("[diagnose] Backup [\(account.email)]: OK (email=\(backupEmail))")
+                } else {
+                    log.warning("[diagnose] Backup [\(account.email)]: EMPTY — metadata is intact but the token carries no OAuth secret; switch will fail until re-authenticated")
+                }
             } else {
                 log.warning("[diagnose] Backup [\(account.email)]: MISSING — switch will fail")
             }

--- a/CCSwitcher/Services/ClaudeService.swift
+++ b/CCSwitcher/Services/ClaudeService.swift
@@ -397,10 +397,26 @@ final class ClaudeService: @unchecked Sendable {
 
         log.info("[switchAccount] Switching from \(currentAccount.id) to \(targetAccount.id)")
 
+        // A backup with both OAuth secrets blanked cannot authenticate, and
+        // Step 4 is far too late to find that out: by then the target's dead
+        // credentials are already live and the source account is gone with
+        // them. Refuse before anything is written.
+        guard targetBackup.hasUsableCredentials else {
+            log.error("[switchAccount] ABORT: stored backup for \(targetAccount.id) carries no OAuth secret")
+            throw ClaudeServiceError.backupCredentialsUnusable(email: targetAccount.email)
+        }
+
         // 1. Back up current account (token + oauthAccount)
+        //
+        // Kept in hand past the backup write as well. Step 3 overwrites the
+        // live credentials before Step 4 can judge them, so these two values
+        // are the only remaining copy of what the CLI was authenticated with
+        // if the switch is rejected.
         log.info("[switchAccount] Step 1: Backing up current account...")
-        if let currentToken = keychain.readClaudeToken(),
-           let currentOAuth = keychain.readOAuthAccount() {
+        let previousToken = keychain.readClaudeToken()
+        let previousOAuthAccount = keychain.readOAuthAccount()
+        if let currentToken = previousToken,
+           let currentOAuth = previousOAuthAccount {
             let email = (currentOAuth["emailAddress"]?.value as? String) ?? "?"
             if email == currentAccount.email {
                 let saved = keychain.saveAccountBackup(token: currentToken, oauthAccount: currentOAuth, forAccountId: currentAccount.id.uuidString)
@@ -410,6 +426,23 @@ final class ClaudeService: @unchecked Sendable {
             }
         } else {
             log.warning("[switchAccount] Step 1: Could not read current token or oauthAccount")
+        }
+
+        /// Restores the credentials the CLI held before Step 3 ran.
+        ///
+        /// Steps 3 and 4 are not one operation. Step 3 has already replaced the
+        /// live token and `~/.claude.json` by the time Step 4 gets to reject
+        /// them, so a failure that returns without this leaves the user signed
+        /// out of the account they were on as well as the one they asked for,
+        /// with no obvious way back other than a browser re-login.
+        func rollback(after reason: String) {
+            guard let previousToken, let previousOAuthAccount else {
+                log.error("[switchAccount] Rollback after \(reason) skipped: no pre-switch credentials were captured")
+                return
+            }
+            let tokenRestored = keychain.writeClaudeToken(previousToken)
+            let oauthRestored = keychain.writeOAuthAccount(previousOAuthAccount)
+            log.info("[switchAccount] Rolled back to \(currentAccount.id) after \(reason): token=\(tokenRestored), oauthAccount=\(oauthRestored)")
         }
 
         // 2. Target backup was resolved and validated by the caller.
@@ -423,21 +456,31 @@ final class ClaudeService: @unchecked Sendable {
         }
         guard keychain.writeOAuthAccount(targetBackup.oauthAccount) else {
             log.error("[switchAccount] Step 3: Failed to write oauthAccount to ~/.claude.json!")
+            rollback(after: "the oauthAccount write failed")
             throw ClaudeServiceError.oauthAccountWriteFailed
         }
         log.info("[switchAccount] Step 3: Both token and oauthAccount written")
 
         // 4. Verify
         log.info("[switchAccount] Step 4: Verifying with `claude auth status`...")
-        let status = try await getAuthStatus()
+        let status: AuthStatus
+        do {
+            status = try await getAuthStatus()
+        } catch {
+            log.error("[switchAccount] Step 4: Could not read auth status: \(error.localizedDescription)")
+            rollback(after: "the verification call failed")
+            throw error
+        }
         guard status.loggedIn else {
             log.error("[switchAccount] Step 4: Not logged in after switch!")
+            rollback(after: "the CLI reported no login")
             throw ClaudeServiceError.switchVerificationFailed
         }
 
         if let email = status.email {
             guard email == targetAccount.email else {
                 log.error("[switchAccount] Step 4: Logged in as \(email) instead of \(targetAccount.email)")
+                rollback(after: "the CLI reported a different account")
                 throw ClaudeServiceError.switchWrongAccount(expected: targetAccount.email, actual: email)
             }
             log.info("[switchAccount] Step 4: Switch verified — logged in as \(email)")
@@ -453,6 +496,7 @@ final class ClaudeService: @unchecked Sendable {
         let shadowedBy = status.shadowingAuthMethod ?? "unknown"
         log.warning("[switchAccount] Step 4: CLI reports authMethod=\(shadowedBy) and omits the account identity; verifying against the credential store instead")
         guard credentialsOnDiskMatch(backup: targetBackup, email: targetAccount.email) else {
+            rollback(after: "the credential store did not match what we wrote")
             throw ClaudeServiceError.switchVerificationFailed
         }
         log.info("[switchAccount] Step 4: Switch verified against the credential store (CLI identity hidden by \(shadowedBy))")
@@ -704,6 +748,7 @@ enum ClaudeServiceError: LocalizedError {
     case oauthAccountWriteFailed
     case switchVerificationFailed
     case switchWrongAccount(expected: String, actual: String)
+    case backupCredentialsUnusable(email: String)
 
     var errorDescription: String? {
         switch self {
@@ -723,6 +768,8 @@ enum ClaudeServiceError: LocalizedError {
             return "Account switch verification failed"
         case .switchWrongAccount(let expected, let actual):
             return "Switch failed: expected \(expected) but got \(actual). Try removing and re-adding the account."
+        case .backupCredentialsUnusable(let email):
+            return "The stored credentials for \(email) are empty. Use re-authenticate to sign in again."
         }
     }
 }

--- a/CCSwitcher/Services/KeychainService.swift
+++ b/CCSwitcher/Services/KeychainService.swift
@@ -7,6 +7,31 @@ private let log = FileLog("Keychain")
 struct AccountBackup: Codable {
     let token: String
     let oauthAccount: [String: AnyCodable]
+
+    /// Whether the stored token still carries an OAuth secret the CLI could
+    /// authenticate with.
+    ///
+    /// A capture that runs while the CLI holds no live login writes back a
+    /// full-looking envelope with `accessToken` and `refreshToken` both set to
+    /// the empty string. Nothing else about that backup looks wrong: the
+    /// `oauthAccount` block is intact, the email is right, the scopes and
+    /// `subscriptionType` are right, and the JSON is only a couple of hundred
+    /// bytes shorter than a good one. So it survives every existing check,
+    /// gets written over a working login, and fails verification a moment
+    /// later.
+    ///
+    /// An envelope with no `claudeAiOauth` block at all is left alone: that is
+    /// an auth shape this check does not know about, and refusing it would
+    /// block switches that work today.
+    var hasUsableCredentials: Bool {
+        guard let data = token.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return false }
+        guard let oauth = root["claudeAiOauth"] as? [String: Any] else { return true }
+        let accessToken = oauth["accessToken"] as? String ?? ""
+        let refreshToken = oauth["refreshToken"] as? String ?? ""
+        return !accessToken.isEmpty || !refreshToken.isEmpty
+    }
 }
 
 /// Type-erased Codable wrapper for heterogeneous JSON values.

--- a/CCSwitcher/en.lproj/Localizable.strings
+++ b/CCSwitcher/en.lproj/Localizable.strings
@@ -130,6 +130,7 @@
 "Account already exists - credentials refreshed" = "Account already exists - credentials refreshed";
 "Could not capture credentials" = "Could not capture credentials";
 "No stored credentials for %@. Use re-authenticate to fix." = "No stored credentials for %@. Use re-authenticate to fix.";
+"The stored credentials for %@ are empty. Use re-authenticate to sign in again." = "The stored credentials for %@ are empty. Use re-authenticate to sign in again.";
 "Logged in as %@, but expected %@. Credentials not updated." = "Logged in as %1$@, but expected %2$@. Credentials not updated.";
 "Claude CLI is authenticating via %@ instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again." = "Claude CLI is authenticating via %@ instead of a stored claude.ai login, so it reports no account. Unset ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_PROFILE and remove any apiKeyHelper, then try again.";
 "Switched to %@, but the Claude CLI is authenticating via %@ instead of the stored login, so it will not use this account." = "Switched to %1$@, but the Claude CLI is authenticating via %2$@ instead of the stored login, so it will not use this account.";


### PR DESCRIPTION
## What happens

A switch fails at Step 4, and the failure leaves the target's credentials live. The user is now signed out of the account they started on as well as the one they asked for. Every later switch fails the same way, because the store is already in the state that caused it. The only way out is the app's own re-authenticate, and that only repairs one account.

On the machine this came from (1.12.0 build 66, macOS 26, two accounts, emails replaced with A and B) it ran for four days: first failure 2026-08-27T15:38Z, twelve consecutive failed switches after it, all `exit 1`, no successful switch in between.

```
[switchAccount] Step 3: Writing target credentials...
[switchAccount] Step 3: Both token and oauthAccount written
[switchAccount] Step 4: Verifying with `claude auth status`...
[runClaude] Failed (exit 1)
[switchTo] Switch failed: Claude CLI error: exit 1
```

## Cause 1: an emptied backup looks exactly like a good one

Reading that machine's backup store directly:

| slot | token bytes | `accessToken` | `refreshToken` | `expiresAt` |
|---|---|---|---|---|
| A | 4595 | 108 chars | 108 chars | valid |
| B | 4374 | `""` | `""` | epoch 0 |

B's envelope is otherwise intact. The `oauthAccount` block is there, the email is right, `scopes` and `subscriptionType` are right, and the JSON is 221 bytes shorter than a working one. So `lookupAccountBackup` returns `.found`, `isSwitchable` says yes, and `diagnoseTokenHealth` reports `Backup [B]: OK (email=B)` because it checks the `oauthAccount` metadata, which is clean. Step 3 then writes two empty strings over a live login.

A capture running while the CLI holds no live login is enough to produce this.

## Cause 2: the failure path is one-way

Step 3 and Step 4 are not one operation. By the time `claude auth status` rejects the credentials, Step 3 has already replaced the keychain token and `~/.claude.json`. `switchAccount` throws, `switchTo` sets `errorMessage`, and nothing puts back what was there.

That is what makes Cause 1 expensive rather than annoying. One bad backup takes out the good account too, and the user cannot switch back to recover.

## The patch

`AccountBackup.hasUsableCredentials` parses the stored token and reports whether `claudeAiOauth` still carries a non-empty `accessToken` or `refreshToken`. Checked in three places:

- `switchTo`, before anything is written, with a message pointing at re-authenticate.
- `isSwitchable`, so auto-switch cannot pick an emptied account. There is no user in front of that path to read an error.
- `switchAccount`, as a last guard before Step 1.

A `rollback(after:)` in `switchAccount` restores the pre-Step-3 token and `oauthAccount` on every failure path after the write: the `oauthAccount` write failing, `getAuthStatus` throwing, `loggedIn` false, the wrong account coming back, and the credential-store comparison failing.

An envelope with no `claudeAiOauth` block at all is treated as usable. That is an auth shape this check does not model, and rejecting it would block switches that work today.

## Relationship to #25

#25 covers how a slot ends up holding the *wrong* account's token. This covers a slot holding *no* token, and the missing rollback. Different failures, and neither fix removes the need for the other. Both touch `switchAccount` Step 1, so there is a small textual conflict if the `CredentialAnchor` work lands first. I am happy to rebase on top of it.

## Testing

- `xcodebuild -scheme CCSwitcher -configuration Debug -destination 'platform=macOS'` on Xcode 26.6: BUILD SUCCEEDED.
- `hasUsableCredentials` run verbatim against the real two-account store above: the emptied slot returns `false`, the working slot returns `true`.
- Synthetic cases: no `claudeAiOauth` block returns `true`, both secrets blank returns `false`, refresh-only returns `true`, access-only returns `true`, non-JSON returns `false`.

Not tested: I have not driven the rollback end to end against a live account, since that means deliberately breaking a working login on a machine that uses it. The rollback paths are verified by reading, not by running.

The new string is added to `en.lproj` only. The other four locales fall back to the English key rather than shipping untranslated text under a translated file.
