### PR TITLE
Show model-scoped weekly limits (e.g. Fable) on account cards

### DIFF
--- a/CCSwitcher/Models/UsageData.swift
+++ b/CCSwitcher/Models/UsageData.swift
@@ -11,6 +11,15 @@ struct UsageAPIResponse: Codable {
     let sevenDayCowork: UsageWindow?
     let iguanaNecktie: UsageWindow?
     let extraUsage: ExtraUsage?
+    /// Canonical list of every limit window the account is subject to.
+    ///
+    /// The top-level keys above are a fixed, partly code-named set: a weekly
+    /// limit scoped to one model arrives as `weekly_scoped` in here, and the
+    /// only place its model name exists is `scope.model.display_name`. An
+    /// account can therefore sit at 100% on a per-model weekly limit while
+    /// `five_hour` and `seven_day` both look healthy, which is exactly the
+    /// case the card used to render as "everything is fine".
+    let limits: [UsageLimit]?
 
     enum CodingKeys: String, CodingKey {
         case fiveHour = "five_hour"
@@ -21,6 +30,116 @@ struct UsageAPIResponse: Codable {
         case sevenDayCowork = "seven_day_cowork"
         case iguanaNecktie = "iguana_necktie"
         case extraUsage = "extra_usage"
+        case limits
+    }
+}
+
+// MARK: - Limits array
+
+/// One entry of `limits`. `kind` is `session`, `weekly_all` or `weekly_scoped`
+/// today; unknown kinds are kept and rendered from their own name so a new
+/// server-side window shows up without an app update.
+struct UsageLimit: Codable {
+    let kind: String?
+    let group: String?
+    let percent: Double?
+    let severity: String?
+    let resetsAt: String?
+    let scope: UsageLimitScope?
+    let isActive: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case kind, group, percent, severity, scope
+        case resetsAt = "resets_at"
+        case isActive = "is_active"
+    }
+
+    /// "Fable", "Opus"… for a model-scoped window; nil for account-wide ones.
+    var scopeName: String? {
+        scope?.model?.displayName ?? scope?.surface
+    }
+}
+
+struct UsageLimitScope: Codable {
+    let model: UsageLimitModel?
+    let surface: String?
+}
+
+struct UsageLimitModel: Codable {
+    let id: String?
+    let displayName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case displayName = "display_name"
+    }
+}
+
+// MARK: - Display windows
+
+/// A single row of an account card, already resolved to a title and a bar.
+struct UsageDisplayWindow: Identifiable {
+    let id: String
+    /// Untranslated scope suffix ("Fable"); nil for Session / account-wide Weekly.
+    let scopeName: String?
+    let isSession: Bool
+    let utilization: Double?
+    let resetsAt: String?
+    /// The window the API says is the one actually constraining the account.
+    let isLimiting: Bool
+
+    var window: UsageWindow { UsageWindow(utilization: utilization, resetsAt: resetsAt) }
+}
+
+extension UsageAPIResponse {
+    /// Every limit row to draw, in a stable order: session first, then the
+    /// account-wide weekly, then model-scoped weeklies (worst first).
+    ///
+    /// Falls back to the legacy top-level keys when `limits` is absent, so an
+    /// older or trimmed response still renders exactly what it used to.
+    var displayWindows: [UsageDisplayWindow] {
+        if let limits, !limits.isEmpty {
+            var rows: [UsageDisplayWindow] = []
+            for (index, limit) in limits.enumerated() {
+                let kind = limit.kind ?? limit.group ?? "limit"
+                let isSession = (kind == "session") || (limit.group == "session")
+                rows.append(
+                    UsageDisplayWindow(
+                        id: "\(kind)-\(limit.scopeName ?? "all")-\(index)",
+                        scopeName: limit.scopeName,
+                        isSession: isSession,
+                        utilization: limit.percent,
+                        resetsAt: limit.resetsAt,
+                        isLimiting: limit.isActive == true
+                    )
+                )
+            }
+            return rows.sorted { lhs, rhs in
+                if lhs.isSession != rhs.isSession { return lhs.isSession }
+                if (lhs.scopeName == nil) != (rhs.scopeName == nil) { return lhs.scopeName == nil }
+                return (lhs.utilization ?? 0) > (rhs.utilization ?? 0)
+            }
+        }
+
+        var rows: [UsageDisplayWindow] = []
+        if let fiveHour {
+            rows.append(UsageDisplayWindow(id: "five_hour", scopeName: nil, isSession: true,
+                                           utilization: fiveHour.utilization, resetsAt: fiveHour.resetsAt,
+                                           isLimiting: false))
+        }
+        if let sevenDay {
+            rows.append(UsageDisplayWindow(id: "seven_day", scopeName: nil, isSession: false,
+                                           utilization: sevenDay.utilization, resetsAt: sevenDay.resetsAt,
+                                           isLimiting: false))
+        }
+        for (name, window) in [("Opus", sevenDayOpus), ("Sonnet", sevenDaySonnet)] {
+            if let window, window.utilization != nil {
+                rows.append(UsageDisplayWindow(id: "seven_day_\(name)", scopeName: name, isSession: false,
+                                               utilization: window.utilization, resetsAt: window.resetsAt,
+                                               isLimiting: false))
+            }
+        }
+        return rows
     }
 }
 

--- a/CCSwitcher/Views/UsageDashboardView.swift
+++ b/CCSwitcher/Views/UsageDashboardView.swift
@@ -279,22 +279,25 @@ struct UsageDashboardView: View {
 
     @ViewBuilder
     private func usageBars(_ usage: UsageAPIResponse) -> some View {
-        if let session = usage.fiveHour {
+        ForEach(usage.displayWindows) { row in
             usageRow(
-                label: "Session",
-                resetText: session.resetTimeString,
-                utilization: session.utilization ?? 0,
-                kind: .session
+                title: title(for: row),
+                resetText: row.window.resetTimeString,
+                utilization: row.utilization ?? 0,
+                kind: row.isSession ? .session : .weekly,
+                isLimiting: row.isLimiting
             )
         }
-        if let weekly = usage.sevenDay {
-            usageRow(
-                label: "Weekly",
-                resetText: weekly.resetTimeString,
-                utilization: weekly.utilization ?? 0,
-                kind: .weekly
-            )
-        }
+    }
+
+    /// "Session", "Weekly", or "Weekly · Fable" — the scope name comes from the
+    /// API and is a product name, so it is appended rather than translated.
+    private func title(for row: UsageDisplayWindow) -> String {
+        let base = row.isSession
+            ? String(localized: "Session", bundle: L10n.bundle)
+            : String(localized: "Weekly", bundle: L10n.bundle)
+        guard let scopeName = row.scopeName else { return base }
+        return "\(base) · \(scopeName)"
     }
 
     @ViewBuilder
@@ -320,14 +323,17 @@ struct UsageDashboardView: View {
 
     // MARK: - Usage Row
 
-    private func usageRow(label: LocalizedStringKey, resetText: String?, utilization: Double, kind: LimitBarKind) -> some View {
+    private func usageRow(title: String, resetText: String?, utilization: Double, kind: LimitBarKind, isLimiting: Bool = false) -> some View {
         let fillColor = menuBarConfig.limitBarColor(for: kind, utilization: utilization, context: .dashboard)
 
         return VStack(spacing: 5) {
             HStack {
-                Text(label)
+                Text(title)
                     .font(.caption)
                     .foregroundStyle(.textSecondary)
+                if isLimiting {
+                    Badge(text: String(localized: "Limiting", bundle: L10n.bundle), color: .orange)
+                }
                 Spacer()
                 if let resetText {
                     Text("Resets in \(resetText)")

--- a/CCSwitcher/de.lproj/Localizable.strings
+++ b/CCSwitcher/de.lproj/Localizable.strings
@@ -55,6 +55,7 @@
 "Token expired. Switch to this account in Claude Code to refresh." = "Token abgelaufen. Wechseln Sie in Claude Code zu diesem Konto, um es zu aktualisieren.";
 "Session" = "Sitzung";
 "Weekly" = "Wöchentlich";
+"Limiting" = "Begrenzend";
 "Extra usage" = "Zusätzliche Nutzung";
 "On" = "An";
 "Off" = "Aus";

--- a/CCSwitcher/en.lproj/Localizable.strings
+++ b/CCSwitcher/en.lproj/Localizable.strings
@@ -55,6 +55,7 @@
 "Token expired. Switch to this account in Claude Code to refresh." = "Token expired. Switch to this account in Claude Code to refresh.";
 "Session" = "Session";
 "Weekly" = "Weekly";
+"Limiting" = "Limiting";
 "Extra usage" = "Extra usage";
 "On" = "On";
 "Off" = "Off";

--- a/CCSwitcher/fr.lproj/Localizable.strings
+++ b/CCSwitcher/fr.lproj/Localizable.strings
@@ -55,6 +55,7 @@
 "Token expired. Switch to this account in Claude Code to refresh." = "Jeton expiré. Basculez vers ce compte dans Claude Code pour actualiser.";
 "Session" = "Session";
 "Weekly" = "Hebdomadaire";
+"Limiting" = "Limitant";
 "Extra usage" = "Utilisation supplémentaire";
 "On" = "Activé";
 "Off" = "Désactivé";

--- a/CCSwitcher/ja.lproj/Localizable.strings
+++ b/CCSwitcher/ja.lproj/Localizable.strings
@@ -55,6 +55,7 @@
 "Token expired. Switch to this account in Claude Code to refresh." = "トークンが期限切れです。Claude Code でこのアカウントに切り替えて更新してください。";
 "Session" = "セッション";
 "Weekly" = "週間";
+"Limiting" = "制限中";
 "Extra usage" = "追加使用量";
 "On" = "オン";
 "Off" = "オフ";

--- a/CCSwitcher/zh-Hans.lproj/Localizable.strings
+++ b/CCSwitcher/zh-Hans.lproj/Localizable.strings
@@ -55,6 +55,7 @@
 "Token expired. Switch to this account in Claude Code to refresh." = "令牌已过期。请在 Claude Code 中切换到此账户以刷新。";
 "Session" = "会话";
 "Weekly" = "每周";
+"Limiting" = "受限中";
 "Extra usage" = "额外用量";
 "On" = "开启";
 "Off" = "关闭";


### PR DESCRIPTION
### The problem

`/api/oauth/usage` reports each window twice: as the fixed, partly code-named top-level keys (`five_hour`, `seven_day`, `seven_day_opus`, …) **and** as the `limits` array. A weekly limit scoped to one model only exists in the array — `kind: "weekly_scoped"`, model name in `scope.model.display_name`. There is no top-level key for it.

`UsageDashboardView.usageBars` renders `five_hour` and `seven_day` only, so a card can read *Session 2% / Weekly 61%* while the account is at **100% on its weekly Fable limit and blocked**. I hit this on 4 of 5 Max accounts today — the card said everything was fine, Claude Code said "limit reached". Real response (trimmed):

```json
"limits": [
  {"kind":"session",       "percent":2,   "is_active":false, "scope":null},
  {"kind":"weekly_all",    "percent":61,  "is_active":false, "scope":null},
  {"kind":"weekly_scoped", "percent":100, "is_active":true,
   "scope":{"model":{"display_name":"Fable"}}}
]
```

Note `is_active` — the API says outright which window is the one constraining you.

### The change

- `UsageData.swift`: decode `limits` (`UsageLimit` / `UsageLimitScope` / `UsageLimitModel`) and add `UsageAPIResponse.displayWindows`, the resolved row list: session first, then the account-wide weekly, then model-scoped weeklies worst-first.
- `UsageDashboardView`: drive the card from `displayWindows` instead of the two hardcoded keys, and put an orange **Limiting** badge on the `is_active` window.
- New `"Limiting"` string in all five localizations. Scope names (`Fable`, `Opus`) come from the API and are product names, so they are appended, not translated: `Weekly · Fable`.

### Compatibility

- Unknown `kind`s are kept and rendered from their own data, so a new server-side window shows up without an app update.
- If `limits` is absent the card falls back to the old top-level keys — plus `seven_day_opus` / `seven_day_sonnet` when they carry a value — so an older or trimmed response renders exactly as it does today.
- Menu-bar modules are untouched (still 5H / 7D). Happy to add a scoped module in a follow-up if you want one.

### Verification

- `xcodebuild` Debug, macOS: **BUILD SUCCEEDED**, no new warnings.
- Decoding + ordering checked against two captured payloads — a real `limits[]` response and a legacy one with no `limits` key:

```
--- new payload (limits[])
  Session             90.0%  resets=now
  Weekly              78.0%  resets=Wed 1:29 PM
  Weekly · Fable     100.0%  resets=Wed 1:30 PM  [Limiting]
--- legacy payload (no limits[])
  Session             12.0%  resets=now
  Weekly              34.0%  resets=Wed 1:29 PM
  Weekly · Opus       56.0%  resets=Wed 1:29 PM
```